### PR TITLE
2.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 XGBOOST_SCIKIT_LEARN := us-west1-docker.pkg.dev/shiftsmart-api/orient-express/xgboost-scikit-learn
-XGBOOST_TAG := v2.1.2
+XGBOOST_TAG := v2.4.0
 
 IMAGE_ONNX := us-west1-docker.pkg.dev/shiftsmart-api/orient-express/image-onnx
-IMAGE_ONNX_TAG := v2.1.2
+IMAGE_ONNX_TAG := v2.4.0
 
 build_local_xgboost_scikit_learn:
 	docker buildx build --tag $(XGBOOST_SCIKIT_LEARN):$(XGBOOST_TAG)_local -f docker-xgboost-scikit-learn/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ pip install orient_express
 ```
 
 For local development:
+
 ```bash
 pip install -e .
 ```
 
 Or with Poetry:
+
 ```bash
 poetry install
 ```
@@ -75,7 +77,7 @@ vertex_model.deploy_to_endpoint(
 
 # remote prediction API depends on the endpoint container deployed with the model
 predictions = vertex_model.remote_predict(
-    [{"image": "https://storage.googleapis.com/ssm-media-uploads/example.jpg"}], 
+    [{"image": "https://storage.googleapis.com/ssm-media-uploads/example.jpg"}],
     endpoint_name="my-classifier-endpoint"
 )
 ```
@@ -152,19 +154,20 @@ predictions = local_predictor.predict(X_test)
 ### Platform Support Matrix
 
 | Platform | Architecture | ONNX Runtime Package | CUDA Available |
-|----------|--------------|---------------------|----------------|
-| Linux    | x86_64       | onnxruntime-gpu     | Yes            |
-| Linux    | aarch64      | onnxruntime         | No             |
-| Windows  | x64 (AMD64)  | onnxruntime-gpu     | Yes            |
-| Windows  | ARM64        | onnxruntime         | No             |
-| macOS    | x86_64       | onnxruntime         | No             |
-| macOS    | arm64        | onnxruntime         | No             |
+| -------- | ------------ | -------------------- | -------------- |
+| Linux    | x86_64       | onnxruntime-gpu      | Yes            |
+| Linux    | aarch64      | onnxruntime          | No             |
+| Windows  | x64 (AMD64)  | onnxruntime-gpu      | Yes            |
+| Windows  | ARM64        | onnxruntime          | No             |
+| macOS    | x86_64       | onnxruntime          | No             |
+| macOS    | arm64        | onnxruntime          | No             |
 
 The appropriate package is installed automatically based on your platform.
 
 ### Selecting CPU vs CUDA Execution
 
 When loading a predictor, use the `device` parameter to specify the execution provider:
+
 ```python
 from orient_express.predictors import ObjectDetectionPredictor
 
@@ -176,6 +179,7 @@ predictor = ObjectDetectionPredictor("/path/to/model", classes, device="cuda")
 ```
 
 When using a Vertex AI model:
+
 ```python
 # CPU inference
 predictor = model.get_local_predictor(device="cpu")
@@ -513,11 +517,8 @@ index = build_vector_index(
     num_workers=8,               # parallel image loading
 )
 
-# Aggregate to one centroid per label
-centroid_index = index.aggregate()
-
 # Save and load
-centroid_index.dump("/path/to/artifact_dir")
+index.dump("/path/to/artifact_dir")
 
 from orient_express.predictors import get_predictor
 loaded_index = get_predictor("/path/to/artifact_dir")
@@ -533,16 +534,23 @@ batch_results = loaded_index.search_batch(query_matrix, k=5)
 
 #### Multi-label support
 
-Vectors can have multiple labels. This is useful when a single visual cluster maps to multiple SKUs:
+Vectors can have composite labels (use tuples). This is useful when a single visual cluster maps to multiple things:
 
 ```python
 index = VectorIndex(
     vectors=feature_matrix,
-    labels=[["sku_101", "sku_102"], ["sku_103"], ["sku_104", "sku_105"]],
+    labels=[("sku_101", "sku_102"), ("sku_103")],
 )
+```
 
-# aggregate() computes one centroid per unique label
-aggregated = index.aggregate()  # 5 vectors, one per SKU
+#### Per-label aggregation
+
+Vector indices in which labels are not unique can be aggregated so that each label has a single centroid.
+If `per_label=True` and the labels are composite (tuples), then the labels will be unpacked and aggregated separately.
+
+```python
+aggregated = index.aggregate(per_label=True)  # 3 vectors, one per label element ["sku_101", "sku_102", "sku_103"]
+aggregated = index.aggregate(per_label=False)  # 2 vectors, one per composite label  [("sku_101", "sku_102"), ("sku_103")]
 ```
 
 #### Output Structure

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ vertex_model.deploy_to_endpoint(
 
 # remote prediction API depends on the endpoint container deployed with the model
 predictions = vertex_model.remote_predict(
+    "my-classifier-endpoint",
     [{"image": "https://storage.googleapis.com/ssm-media-uploads/example.jpg"}],
-    endpoint_name="my-classifier-endpoint"
 )
 ```
 
@@ -539,7 +539,7 @@ Vectors can have composite labels (use tuples). This is useful when a single vis
 ```python
 index = VectorIndex(
     vectors=feature_matrix,
-    labels=[("sku_101", "sku_102"), ("sku_103")],
+    labels=[("sku_101", "sku_102"), ("sku_103",)],
 )
 ```
 

--- a/orient_express/predictors/__init__.py
+++ b/orient_express/predictors/__init__.py
@@ -99,6 +99,7 @@ def load_vector_index(dir: str, metadata: dict | None = None):
     data = np.load(artifact_path, allow_pickle=False)
     vectors = data["vectors"]
     labels = json.loads(str(data["labels_json"]))
+    labels = [tuple(label) if isinstance(label, list) else label for label in labels]
     index = VectorIndex(vectors=vectors, labels=labels)
     index.model_path = artifact_path
     return index

--- a/orient_express/predictors/predictor.py
+++ b/orient_express/predictors/predictor.py
@@ -46,7 +46,7 @@ class ImagePredictor(Predictor):
         self.model_path = model_path
 
     def get_serving_container_image_uri(self):
-        return "us-west1-docker.pkg.dev/shiftsmart-api/orient-express/image-onnx:v2.1.2"
+        return "us-west1-docker.pkg.dev/shiftsmart-api/orient-express/image-onnx:v2.4.0"
 
     def get_serving_container_health_route(self, model_name):
         return f"/v1/models/{model_name}"

--- a/orient_express/predictors/vector_index.py
+++ b/orient_express/predictors/vector_index.py
@@ -59,8 +59,6 @@ class VectorIndex(Predictor):
         self.labels = labels
         self.label_to_idx = {}
 
-        self.multi_label = False
-
         for i, label in enumerate(labels):
             if label not in self.label_to_idx:
                 self.label_to_idx[label] = []
@@ -238,7 +236,6 @@ def build_vector_index(
             returns objects with a .feature attribute (e.g. FeatureExtractionPredictor).
         batch_size: number of crops to process at once.
         normalize: whether to L2-normalize the resulting feature vectors.
-        multi_label: if True, labels are already lists of labels per crop.
         num_workers: number of DataLoader workers for parallel image loading.
     """
     if len(crops) != len(labels):

--- a/orient_express/predictors/vector_index.py
+++ b/orient_express/predictors/vector_index.py
@@ -98,10 +98,10 @@ class VectorIndex(Predictor):
         return all_results
 
     def get_by_idx(self, idx: int) -> np.ndarray:
-        return self.vectors[idx].ex
+        return self.vectors[idx]
 
     def get_by_idxs(self, idxs: list[int]) -> np.ndarray:
-        return np.expand_dims(self.vectors[idxs], axis=0)
+        return self.vectors[idxs]
 
     def get_by_label(self, label: Any) -> np.ndarray:
         return self.vectors[self.label_to_idx[label]]

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -297,14 +297,20 @@ def get_vertex_model(
             return None
     if len(models) > 1:
         warnings.warn(
-            f"Multiple models found with name '{model_name}'. Using the first one."
+            f"Multiple models found with name '{model_name}'. Using the latest one."
         )
 
-    resource_name = models[0].resource_name
+    latest_model = sorted(models, key=lambda x: x.update_time, reverse=True)[0]
+    resource_name = latest_model.resource_name
+
+    if version is None:
+        return VertexModel(
+            latest_model, model_name, project_name, region, int(latest_model.version_id)
+        )
 
     if version is not None:
         try:
-            model = aiplatform.Model(f"{resource_name}@{version}")
+            model = aiplatform.Model(model_name=resource_name, version=str(version))
         except Exception:
             if raise_exception:
                 raise Exception(
@@ -312,10 +318,3 @@ def get_vertex_model(
                 )
             return None
         return VertexModel(model, model_name, project_name, region, version)
-
-    # No version specified — find the latest
-    registry = aiplatform.models.ModelRegistry(model=resource_name)
-    versions = registry.list_versions()
-    latest = sorted(versions, key=lambda x: x.update_time, reverse=True)[0]
-    model = aiplatform.Model(f"{resource_name}@{latest.version_id}")
-    return VertexModel(model, model_name, project_name, region, int(latest.version_id))

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -288,7 +288,6 @@ def get_vertex_model(
 ):
     vertex_init(project_name, region)
     models = aiplatform.Model.list(filter=f"display_name={model_name}")
-
     if not models:
         if raise_exception:
             raise Exception(
@@ -296,24 +295,27 @@ def get_vertex_model(
             )
         else:
             return None
-
     if len(models) > 1:
         warnings.warn(
-            f"Multiple models found with name '{model_name}'. Returning the latest version."
-        )
-    versions = models[0].list_versions()
-
-    if version is None:
-        latest_model = sorted(versions, key=lambda x: x.update_time, reverse=True)[0]
-        return VertexModel(
-            latest_model, model_name, project_name, region, int(latest_model.version_id)
+            f"Multiple models found with name '{model_name}'. Using the first one."
         )
 
-    for v in versions:
-        if int(v.version_id) == version:
-            return VertexModel(v, model_name, project_name, region, version)
+    resource_name = models[0].resource_name
 
-    if raise_exception:
-        raise Exception(
-            f"Model '{model_name}' with version '{version}' not found in registry for project '{project_name}' region '{region}'"
-        )
+    if version is not None:
+        try:
+            model = aiplatform.Model(f"{resource_name}@{version}")
+        except Exception:
+            if raise_exception:
+                raise Exception(
+                    f"Model '{model_name}' with version '{version}' not found in registry for project '{project_name}' region '{region}'"
+                )
+            return None
+        return VertexModel(model, model_name, project_name, region, version)
+
+    # No version specified — find the latest
+    registry = aiplatform.models.ModelRegistry(model=resource_name)
+    versions = registry.list_versions()
+    latest = sorted(versions, key=lambda x: x.update_time, reverse=True)[0]
+    model = aiplatform.Model(f"{resource_name}@{latest.version_id}")
+    return VertexModel(model, model_name, project_name, region, int(latest.version_id))

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -314,7 +314,7 @@ def get_vertex_model(
         except Exception:
             if raise_exception:
                 raise Exception(
-                    f"Model '{model_name}' with version '{version}' not found in registry for project '{project_name}' region '{region}'"
+                    f"Failed to fetch model '{model_name}' with version '{version}' in registry for project '{project_name}' region '{region}'"
                 )
             return None
         return VertexModel(model, model_name, project_name, region, version)

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import warnings
 
 import yaml
 import joblib
@@ -296,18 +297,23 @@ def get_vertex_model(
         else:
             return None
 
+    if len(models) > 1:
+        warnings.warn(
+            f"Multiple models found with name '{model_name}'. Returning the latest version."
+        )
+    versions = models[0].list_versions()
+
     if version is None:
-        latest_model = sorted(models, key=lambda x: x.update_time, reverse=True)[0]
+        latest_model = sorted(versions, key=lambda x: x.update_time, reverse=True)[0]
         return VertexModel(
             latest_model, model_name, project_name, region, int(latest_model.version_id)
         )
 
-    for model in models:
-        if int(model.version_id) == version:
-            return VertexModel(model, model_name, project_name, region, version)
+    for v in versions:
+        if int(v.version_id) == version:
+            return VertexModel(v, model_name, project_name, region, version)
 
     if raise_exception:
         raise Exception(
             f"Model '{model_name}' with version '{version}' not found in registry for project '{project_name}' region '{region}'"
         )
-    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orient_express"
-version = "2.3.1"
+version = "2.4.0"
 description = "A library to simplify model deployment to Vertex AI"
 authors = ["Alexey Zankevich <alex.zankevich@shiftsmart.com>", "Ian Myers <ian.myers@shiftsmart.com>"]
 readme = "README.md"

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -10,6 +10,7 @@ These tests verify that:
 """
 
 import os
+from collections import Counter
 
 import pytest
 import numpy as np
@@ -51,15 +52,15 @@ from orient_express.predictors.vector_index import (
 
 def _assert_labels_match(agg, expected_labels):
     """Assert aggregated labels match expected, ignoring order."""
-    assert sorted(agg.labels, key=str) == sorted(expected_labels, key=str)
+    assert Counter(agg.labels) == Counter(expected_labels)
 
 
-def _get_centroid_for(agg, label):
+def _get_centroid_for(agg, target_label):
     """Look up the centroid vector for a given label."""
-    for i, l in enumerate(agg.labels):
-        if l == label:
+    for i, label in enumerate(agg.labels):
+        if label == target_label:
             return agg.vectors[i]
-    raise ValueError(f"Label {label} not found in {agg.labels}")
+    raise ValueError(f"Label {target_label} not found in {agg.labels}")
 
 
 @pytest.fixture
@@ -1443,8 +1444,8 @@ class TestVectorIndex:
         index.dump(str(tmp_path))
         loaded = load_vector_index(str(tmp_path))
         assert loaded.labels == labels
-        for orig, roundtripped in zip(labels, loaded.labels):
-            assert type(orig) == type(roundtripped)
+        for orig, roundtripped in zip(labels, loaded.labels, strict=True):
+            assert type(orig) is type(roundtripped)
 
     def test_dump_creates_expected_files(self, single_label_index, tmp_path):
         files = single_label_index.dump(str(tmp_path))

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -1270,6 +1270,16 @@ class TestVectorIndex:
         with pytest.raises(KeyError):
             single_label_index.get_by_label("NONEXISTENT")
 
+    def test_get_by_idx(self, single_label_index, normalized_vectors):
+        vec = single_label_index.get_by_idx(0)
+        assert vec.shape == (64,)
+        np.testing.assert_allclose(vec, normalized_vectors[0])
+
+        vecs = single_label_index.get_by_idxs([0, 1])
+        assert vecs.shape == (2, 64)
+        np.testing.assert_allclose(vecs[0], normalized_vectors[0])
+        np.testing.assert_allclose(vecs[1], normalized_vectors[1])
+
     # -- Search ---------------------------------------------------------------
 
     def test_search_self_is_top_match(self, single_label_index, normalized_vectors):

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -144,18 +144,21 @@ class TestArtifactPathConstruction:
         mock_bucket.blob.return_value = mock_blob
 
         # Create existing model with version 3
-        existing_model = MagicMock()
-        existing_model.name = "existing-model-id"
-        existing_model.version_id = "3"
-        existing_model.update_time = datetime(2024, 1, 1)
-        existing_model.gca_resource.artifact_uri = "gs://bucket/models/my-detector/3/"
+        existing_version = MagicMock()
+        existing_version.name = "existing-model-id"
+        existing_version.version_id = "3"
+        existing_version.update_time = datetime(2024, 1, 1)
+        existing_version.gca_resource.artifact_uri = "gs://bucket/models/my-detector/3/"
+
+        parent_model = MagicMock()
+        parent_model.list_versions.return_value = [existing_version]
 
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [existing_model]
+            mock_model_class.list.return_value = [parent_model]
             mock_model_class.upload.return_value = MagicMock(
                 name="new-model", version_id="4"
             )
@@ -267,12 +270,15 @@ class TestVersioningLogic:
 
         existing = mock_vertex_model_factory(name="existing-id", version_id="5")
 
+        parent_model = MagicMock()
+        parent_model.list_versions.return_value = [existing]
+
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [existing]
+            mock_model_class.list.return_value = [parent_model]
             mock_uploaded = MagicMock(name="new-version", version_id="6")
             mock_model_class.upload.return_value = mock_uploaded
 
@@ -301,7 +307,6 @@ class TestVersioningLogic:
         mock_client, mock_bucket = mock_storage_client
         mock_bucket.blob.return_value = MagicMock()
 
-        # Multiple existing versions, not in order
         v1 = mock_vertex_model_factory(
             name="model-v1",
             version_id="1",
@@ -318,13 +323,15 @@ class TestVersioningLogic:
             update_time=datetime(2024, 2, 1),
         )
 
+        parent_model = MagicMock()
+        parent_model.list_versions.return_value = [v1, v3, v2]
+
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            # get_vertex_model sorts by update_time to find latest
-            mock_model_class.list.return_value = [v1, v3, v2]
+            mock_model_class.list.return_value = [parent_model]
             mock_uploaded = MagicMock(name="new-version", version_id="4")
             mock_model_class.upload.return_value = mock_uploaded
 
@@ -369,11 +376,14 @@ class TestGetVertexModel:
             update_time=datetime(2024, 1, 10, 10, 0, 0),
         )
 
+        parent_model = MagicMock()
+        parent_model.list_versions.return_value = [v1, v2, v3]
+
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [v1, v2, v3]
+            mock_model_class.list.return_value = [parent_model]
 
             result = get_vertex_model(
                 model_name="my-model",
@@ -382,7 +392,6 @@ class TestGetVertexModel:
                 version=None,
             )
 
-            # v2 has the latest update_time
             assert result.version == 2
             assert result.vertex_model.name == "model-v2"
 
@@ -392,11 +401,14 @@ class TestGetVertexModel:
         v2 = mock_vertex_model_factory(name="model-v2", version_id="2")
         v3 = mock_vertex_model_factory(name="model-v3", version_id="3")
 
+        parent_model = MagicMock()
+        parent_model.list_versions.return_value = [v1, v2, v3]
+
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [v1, v2, v3]
+            mock_model_class.list.return_value = [parent_model]
 
             result = get_vertex_model(
                 model_name="my-model",
@@ -448,11 +460,14 @@ class TestGetVertexModel:
         v1 = mock_vertex_model_factory(name="model-v1", version_id="1")
         v2 = mock_vertex_model_factory(name="model-v2", version_id="2")
 
+        parent_model = MagicMock()
+        parent_model.list_versions.return_value = [v1, v2]
+
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [v1, v2]
+            mock_model_class.list.return_value = [parent_model]
 
             with pytest.raises(Exception) as exc_info:
                 get_vertex_model(
@@ -471,11 +486,14 @@ class TestGetVertexModel:
         """Returns None when version not found and raise_exception=False."""
         v1 = mock_vertex_model_factory(name="model-v1", version_id="1")
 
+        parent_model = MagicMock()
+        parent_model.list_versions.return_value = [v1]
+
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [v1]
+            mock_model_class.list.return_value = [parent_model]
 
             result = get_vertex_model(
                 model_name="my-model",
@@ -505,6 +523,77 @@ class TestGetVertexModel:
             mock_model_class.list.assert_called_once_with(
                 filter="display_name=specific-model-name"
             )
+
+    def test_warns_when_multiple_models_share_display_name(
+        self, mock_vertex_model_factory
+    ):
+        """Warns user when Model.list returns more than one model resource."""
+        v1 = mock_vertex_model_factory(name="model-v1", version_id="1")
+
+        parent_model_a = MagicMock()
+        parent_model_a.list_versions.return_value = [v1]
+        parent_model_b = MagicMock()
+        parent_model_b.list_versions.return_value = [v1]
+
+        with (
+            patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
+            patch("orient_express.vertex.aiplatform.init"),
+        ):
+            mock_model_class.list.return_value = [parent_model_a, parent_model_b]
+
+            import warnings
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                get_vertex_model(
+                    model_name="my-model",
+                    project_name="test-project",
+                    region="us-central1",
+                )
+                assert len(w) == 1
+                assert (
+                    "my-model" in str(w[0].message).lower()
+                    or "multiple" in str(w[0].message).lower()
+                )
+
+    def test_uses_first_model_when_multiple_share_display_name(
+        self, mock_vertex_model_factory
+    ):
+        """When multiple model resources exist, uses the first one's versions."""
+        v1 = mock_vertex_model_factory(
+            name="model-a-v1", version_id="1", update_time=datetime(2024, 1, 1)
+        )
+        v2 = mock_vertex_model_factory(
+            name="model-a-v2", version_id="2", update_time=datetime(2024, 2, 1)
+        )
+        v3_other = mock_vertex_model_factory(
+            name="model-b-v3", version_id="3", update_time=datetime(2024, 3, 1)
+        )
+
+        parent_model_a = MagicMock()
+        parent_model_a.list_versions.return_value = [v1, v2]
+        parent_model_b = MagicMock()
+        parent_model_b.list_versions.return_value = [v3_other]
+
+        with (
+            patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
+            patch("orient_express.vertex.aiplatform.init"),
+        ):
+            mock_model_class.list.return_value = [parent_model_a, parent_model_b]
+
+            import warnings
+
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                result = get_vertex_model(
+                    model_name="my-model",
+                    project_name="test-project",
+                    region="us-central1",
+                )
+
+            # Should pick v2 (latest from first model), not v3_other
+            assert result.version == 2
+            assert result.vertex_model.name == "model-a-v2"
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -71,7 +71,6 @@ def mock_vertex_model_factory():
     return _create
 
 
-
 @pytest.fixture
 def mock_predictor():
     """Creates a mock Predictor that can be uploaded."""
@@ -146,7 +145,9 @@ class TestArtifactPathConstruction:
 
         # Create existing model returned by Model.list
         parent_model = MagicMock()
-        parent_model.resource_name = "projects/test-project/locations/us-central1/models/existing-model-id"
+        parent_model.resource_name = (
+            "projects/test-project/locations/us-central1/models/existing-model-id"
+        )
         parent_model.name = "existing-model-id"
         parent_model.version_id = "3"
         parent_model.update_time = datetime(2024, 1, 1)
@@ -162,7 +163,10 @@ class TestArtifactPathConstruction:
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
-            patch("orient_express.vertex.aiplatform.models.ModelRegistry", return_value=mock_registry),
+            patch(
+                "orient_express.vertex.aiplatform.models.ModelRegistry",
+                return_value=mock_registry,
+            ),
             patch("orient_express.vertex.aiplatform.init"),
         ):
             mock_model_class.list.return_value = [parent_model]
@@ -276,7 +280,9 @@ class TestVersioningLogic:
         mock_bucket.blob.return_value = MagicMock()
 
         parent_model = MagicMock()
-        parent_model.resource_name = "projects/test-project/locations/us-central1/models/existing-id"
+        parent_model.resource_name = (
+            "projects/test-project/locations/us-central1/models/existing-id"
+        )
         parent_model.name = "existing-id"
         parent_model.version_id = "5"
         parent_model.update_time = datetime(2024, 1, 1)
@@ -290,7 +296,10 @@ class TestVersioningLogic:
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
-            patch("orient_express.vertex.aiplatform.models.ModelRegistry", return_value=mock_registry),
+            patch(
+                "orient_express.vertex.aiplatform.models.ModelRegistry",
+                return_value=mock_registry,
+            ),
             patch("orient_express.vertex.aiplatform.init"),
         ):
             mock_model_class.list.return_value = [parent_model]
@@ -323,7 +332,9 @@ class TestVersioningLogic:
         mock_bucket.blob.return_value = MagicMock()
 
         parent_model = MagicMock()
-        parent_model.resource_name = "projects/test-project/locations/us-central1/models/model-id"
+        parent_model.resource_name = (
+            "projects/test-project/locations/us-central1/models/model-id"
+        )
         parent_model.name = "model-id"
         parent_model.version_id = "3"
         parent_model.update_time = datetime(2024, 3, 1)
@@ -337,7 +348,10 @@ class TestVersioningLogic:
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
-            patch("orient_express.vertex.aiplatform.models.ModelRegistry", return_value=mock_registry),
+            patch(
+                "orient_express.vertex.aiplatform.models.ModelRegistry",
+                return_value=mock_registry,
+            ),
             patch("orient_express.vertex.aiplatform.init"),
         ):
             mock_model_class.list.return_value = [parent_model]
@@ -452,9 +466,7 @@ class TestGetVertexModel:
 
             assert result.version == 2
             assert result.vertex_model == mock_constructed_model
-            mock_model_class.assert_called_with(
-                model_name=m.resource_name, version="2"
-            )
+            mock_model_class.assert_called_with(model_name=m.resource_name, version="2")
 
     def test_raises_when_model_not_found_and_raise_exception_true(self):
         """Raises exception when no models found and raise_exception=True."""

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -71,6 +71,7 @@ def mock_vertex_model_factory():
     return _create
 
 
+
 @pytest.fixture
 def mock_predictor():
     """Creates a mock Predictor that can be uploaded."""
@@ -143,19 +144,25 @@ class TestArtifactPathConstruction:
         mock_blob = MagicMock()
         mock_bucket.blob.return_value = mock_blob
 
-        # Create existing model with version 3
-        existing_version = MagicMock()
-        existing_version.name = "existing-model-id"
-        existing_version.version_id = "3"
-        existing_version.update_time = datetime(2024, 1, 1)
-        existing_version.gca_resource.artifact_uri = "gs://bucket/models/my-detector/3/"
-
+        # Create existing model returned by Model.list
         parent_model = MagicMock()
-        parent_model.list_versions.return_value = [existing_version]
+        parent_model.resource_name = "projects/test-project/locations/us-central1/models/existing-model-id"
+        parent_model.name = "existing-model-id"
+        parent_model.version_id = "3"
+        parent_model.update_time = datetime(2024, 1, 1)
+        parent_model.gca_resource.artifact_uri = "gs://bucket/models/my-detector/3/"
+
+        # Mock ModelRegistry for version listing
+        mock_registry = MagicMock()
+        mock_version_info = MagicMock()
+        mock_version_info.version_id = "3"
+        mock_version_info.version_update_time = datetime(2024, 1, 1)
+        mock_registry.list_versions.return_value = [mock_version_info]
 
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
+            patch("orient_express.vertex.aiplatform.models.ModelRegistry", return_value=mock_registry),
             patch("orient_express.vertex.aiplatform.init"),
         ):
             mock_model_class.list.return_value = [parent_model]
@@ -268,14 +275,22 @@ class TestVersioningLogic:
         mock_client, mock_bucket = mock_storage_client
         mock_bucket.blob.return_value = MagicMock()
 
-        existing = mock_vertex_model_factory(name="existing-id", version_id="5")
-
         parent_model = MagicMock()
-        parent_model.list_versions.return_value = [existing]
+        parent_model.resource_name = "projects/test-project/locations/us-central1/models/existing-id"
+        parent_model.name = "existing-id"
+        parent_model.version_id = "5"
+        parent_model.update_time = datetime(2024, 1, 1)
+
+        mock_registry = MagicMock()
+        mock_version_info = MagicMock()
+        mock_version_info.version_id = "5"
+        mock_version_info.version_update_time = datetime(2024, 1, 1)
+        mock_registry.list_versions.return_value = [mock_version_info]
 
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
+            patch("orient_express.vertex.aiplatform.models.ModelRegistry", return_value=mock_registry),
             patch("orient_express.vertex.aiplatform.init"),
         ):
             mock_model_class.list.return_value = [parent_model]
@@ -307,28 +322,22 @@ class TestVersioningLogic:
         mock_client, mock_bucket = mock_storage_client
         mock_bucket.blob.return_value = MagicMock()
 
-        v1 = mock_vertex_model_factory(
-            name="model-v1",
-            version_id="1",
-            update_time=datetime(2024, 1, 1),
-        )
-        v3 = mock_vertex_model_factory(
-            name="model-v3",
-            version_id="3",
-            update_time=datetime(2024, 3, 1),
-        )
-        v2 = mock_vertex_model_factory(
-            name="model-v2",
-            version_id="2",
-            update_time=datetime(2024, 2, 1),
-        )
-
         parent_model = MagicMock()
-        parent_model.list_versions.return_value = [v1, v3, v2]
+        parent_model.resource_name = "projects/test-project/locations/us-central1/models/model-id"
+        parent_model.name = "model-id"
+        parent_model.version_id = "3"
+        parent_model.update_time = datetime(2024, 3, 1)
+
+        mock_registry = MagicMock()
+        vi1 = MagicMock(version_id="1", version_update_time=datetime(2024, 1, 1))
+        vi2 = MagicMock(version_id="2", version_update_time=datetime(2024, 2, 1))
+        vi3 = MagicMock(version_id="3", version_update_time=datetime(2024, 3, 1))
+        mock_registry.list_versions.return_value = [vi1, vi3, vi2]
 
         with (
             patch("orient_express.vertex.storage.Client", return_value=mock_client),
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
+            patch("orient_express.vertex.aiplatform.models.ModelRegistry", return_value=mock_registry),
             patch("orient_express.vertex.aiplatform.init"),
         ):
             mock_model_class.list.return_value = [parent_model]
@@ -356,34 +365,37 @@ class TestVersioningLogic:
 class TestGetVertexModel:
     """Tests for get_vertex_model filtering and sorting."""
 
-    def test_returns_latest_by_update_time_when_no_version_specified(
-        self, mock_vertex_model_factory
+    def _make_model(
+        self,
+        resource_name="projects/test-project/locations/us-central1/models/model-123",
+        version_id="1",
+        update_time=None,
     ):
-        """Without version parameter, returns model with most recent update_time."""
-        v1 = mock_vertex_model_factory(
-            name="model-v1",
+        """Helper to create a Model.list() result with real string attributes."""
+        model = MagicMock()
+        model.resource_name = resource_name
+        model.version_id = version_id
+        model.update_time = update_time or datetime(2024, 1, 1, 12, 0, 0)
+        return model
+
+    def test_returns_default_version_when_no_version_specified(self):
+        """Without version parameter, returns the model with most recent update_time (default version)."""
+        m1 = self._make_model(
+            resource_name="projects/test-project/locations/us-central1/models/aaa",
             version_id="1",
             update_time=datetime(2024, 1, 1, 10, 0, 0),
         )
-        v2 = mock_vertex_model_factory(
-            name="model-v2",
+        m2 = self._make_model(
+            resource_name="projects/test-project/locations/us-central1/models/bbb",
             version_id="2",
             update_time=datetime(2024, 1, 15, 10, 0, 0),
         )
-        v3 = mock_vertex_model_factory(
-            name="model-v3",
-            version_id="3",
-            update_time=datetime(2024, 1, 10, 10, 0, 0),
-        )
-
-        parent_model = MagicMock()
-        parent_model.list_versions.return_value = [v1, v2, v3]
 
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [parent_model]
+            mock_model_class.list.return_value = [m1, m2]
 
             result = get_vertex_model(
                 model_name="my-model",
@@ -392,23 +404,44 @@ class TestGetVertexModel:
                 version=None,
             )
 
+            # m2 has the latest update_time
             assert result.version == 2
-            assert result.vertex_model.name == "model-v2"
+            assert result.vertex_model == m2
 
-    def test_returns_specific_version_when_specified(self, mock_vertex_model_factory):
-        """With version parameter, returns the matching version."""
-        v1 = mock_vertex_model_factory(name="model-v1", version_id="1")
-        v2 = mock_vertex_model_factory(name="model-v2", version_id="2")
-        v3 = mock_vertex_model_factory(name="model-v3", version_id="3")
-
-        parent_model = MagicMock()
-        parent_model.list_versions.return_value = [v1, v2, v3]
+    def test_returns_single_model_when_only_one_exists(self):
+        """With a single model in the registry, returns it directly."""
+        m = self._make_model(version_id="3", update_time=datetime(2024, 5, 1))
 
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [parent_model]
+            mock_model_class.list.return_value = [m]
+
+            result = get_vertex_model(
+                model_name="my-model",
+                project_name="test-project",
+                region="us-central1",
+                version=None,
+            )
+
+            assert result.version == 3
+            assert result.vertex_model == m
+
+    def test_returns_specific_version_when_specified(self):
+        """With version parameter, constructs Model with resource_name and version."""
+        m = self._make_model()
+
+        mock_constructed_model = MagicMock()
+        mock_constructed_model.name = "model-v2"
+        mock_constructed_model.version_id = "2"
+
+        with (
+            patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
+            patch("orient_express.vertex.aiplatform.init"),
+        ):
+            mock_model_class.list.return_value = [m]
+            mock_model_class.return_value = mock_constructed_model
 
             result = get_vertex_model(
                 model_name="my-model",
@@ -418,7 +451,10 @@ class TestGetVertexModel:
             )
 
             assert result.version == 2
-            assert result.vertex_model.name == "model-v2"
+            assert result.vertex_model == mock_constructed_model
+            mock_model_class.assert_called_with(
+                model_name=m.resource_name, version="2"
+            )
 
     def test_raises_when_model_not_found_and_raise_exception_true(self):
         """Raises exception when no models found and raise_exception=True."""
@@ -455,19 +491,16 @@ class TestGetVertexModel:
 
             assert result is None
 
-    def test_raises_when_specific_version_not_found(self, mock_vertex_model_factory):
-        """Raises exception when requested version doesn't exist."""
-        v1 = mock_vertex_model_factory(name="model-v1", version_id="1")
-        v2 = mock_vertex_model_factory(name="model-v2", version_id="2")
-
-        parent_model = MagicMock()
-        parent_model.list_versions.return_value = [v1, v2]
+    def test_raises_when_specific_version_not_found(self):
+        """Raises exception when Model() constructor fails for nonexistent version."""
+        m = self._make_model()
 
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [parent_model]
+            mock_model_class.list.return_value = [m]
+            mock_model_class.side_effect = Exception("not found")
 
             with pytest.raises(Exception) as exc_info:
                 get_vertex_model(
@@ -480,20 +513,16 @@ class TestGetVertexModel:
 
             assert "version" in str(exc_info.value).lower()
 
-    def test_returns_none_when_specific_version_not_found_and_raise_false(
-        self, mock_vertex_model_factory
-    ):
-        """Returns None when version not found and raise_exception=False."""
-        v1 = mock_vertex_model_factory(name="model-v1", version_id="1")
-
-        parent_model = MagicMock()
-        parent_model.list_versions.return_value = [v1]
+    def test_returns_none_when_specific_version_not_found_and_raise_false(self):
+        """Returns None when Model() constructor fails and raise_exception=False."""
+        m = self._make_model()
 
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [parent_model]
+            mock_model_class.list.return_value = [m]
+            mock_model_class.side_effect = Exception("not found")
 
             result = get_vertex_model(
                 model_name="my-model",
@@ -505,7 +534,7 @@ class TestGetVertexModel:
 
             assert result is None
 
-    def test_uses_display_name_filter_in_list(self, mock_vertex_model_factory):
+    def test_uses_display_name_filter_in_list(self):
         """Model.list is called with correct display_name filter."""
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
@@ -524,22 +553,22 @@ class TestGetVertexModel:
                 filter="display_name=specific-model-name"
             )
 
-    def test_warns_when_multiple_models_share_display_name(
-        self, mock_vertex_model_factory
-    ):
+    def test_warns_when_multiple_models_share_display_name(self):
         """Warns user when Model.list returns more than one model resource."""
-        v1 = mock_vertex_model_factory(name="model-v1", version_id="1")
-
-        parent_model_a = MagicMock()
-        parent_model_a.list_versions.return_value = [v1]
-        parent_model_b = MagicMock()
-        parent_model_b.list_versions.return_value = [v1]
+        m_a = self._make_model(
+            resource_name="projects/test/locations/us-central1/models/aaa",
+            update_time=datetime(2024, 2, 1),
+        )
+        m_b = self._make_model(
+            resource_name="projects/test/locations/us-central1/models/bbb",
+            update_time=datetime(2024, 1, 1),
+        )
 
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [parent_model_a, parent_model_b]
+            mock_model_class.list.return_value = [m_a, m_b]
 
             import warnings
 
@@ -556,30 +585,25 @@ class TestGetVertexModel:
                     or "multiple" in str(w[0].message).lower()
                 )
 
-    def test_uses_first_model_when_multiple_share_display_name(
-        self, mock_vertex_model_factory
-    ):
-        """When multiple model resources exist, uses the first one's versions."""
-        v1 = mock_vertex_model_factory(
-            name="model-a-v1", version_id="1", update_time=datetime(2024, 1, 1)
+    def test_picks_most_recently_updated_when_multiple_models(self):
+        """When multiple model resources exist, picks the one with latest update_time."""
+        m_old = self._make_model(
+            resource_name="projects/test/locations/us-central1/models/old",
+            version_id="1",
+            update_time=datetime(2024, 1, 1),
         )
-        v2 = mock_vertex_model_factory(
-            name="model-a-v2", version_id="2", update_time=datetime(2024, 2, 1)
+        m_new = self._make_model(
+            resource_name="projects/test/locations/us-central1/models/new",
+            version_id="5",
+            update_time=datetime(2024, 6, 1),
         )
-        v3_other = mock_vertex_model_factory(
-            name="model-b-v3", version_id="3", update_time=datetime(2024, 3, 1)
-        )
-
-        parent_model_a = MagicMock()
-        parent_model_a.list_versions.return_value = [v1, v2]
-        parent_model_b = MagicMock()
-        parent_model_b.list_versions.return_value = [v3_other]
 
         with (
             patch("orient_express.vertex.aiplatform.Model") as mock_model_class,
             patch("orient_express.vertex.aiplatform.init"),
         ):
-            mock_model_class.list.return_value = [parent_model_a, parent_model_b]
+            # Return them in non-sorted order
+            mock_model_class.list.return_value = [m_old, m_new]
 
             import warnings
 
@@ -591,9 +615,9 @@ class TestGetVertexModel:
                     region="us-central1",
                 )
 
-            # Should pick v2 (latest from first model), not v3_other
-            assert result.version == 2
-            assert result.vertex_model.name == "model-a-v2"
+            # Should pick m_new (latest update_time)
+            assert result.version == 5
+            assert result.vertex_model == m_new
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- fixes bug in which loading vertex model always returned the default model version and raised an error when non-default versions are requested
- updates tests in respect to above issue: GCP mocks more accurately reflect GCP model registry structures
- `VectorIndex` labels can be any hashable type
- `per_label` in `VectorIndex.aggregate` only applies to labels that are tuples
- adds vector fetch helper functions to the `VectorIndex` api
- docker image version bumps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Label-based lookup for vector indexes with support for scalar (int, string) and tuple labels; new retrieval methods and per-label aggregation mode.

* **Improvements**
  * More robust model version selection with warnings and explicit version handling.
  * README refreshed with CPU/CUDA examples, composite-label usage, and aggregation guidance.

* **Chores**
  * Serving/build container images and project version updated to v2.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->