### PR TITLE
2.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 XGBOOST_SCIKIT_LEARN := us-west1-docker.pkg.dev/shiftsmart-api/orient-express/xgboost-scikit-learn
-XGBOOST_TAG := v2.4.1
+XGBOOST_TAG := v2.4.2
 
 IMAGE_ONNX := us-west1-docker.pkg.dev/shiftsmart-api/orient-express/image-onnx
-IMAGE_ONNX_TAG := v2.4.1
+IMAGE_ONNX_TAG := v2.4.2
 
 GOOGLE_CLOUD_PROJECT ?=
 REGION ?= us-west1

--- a/README.md
+++ b/README.md
@@ -566,6 +566,191 @@ class SearchResult:
 
 ---
 
+## Deployed Endpoint APIs
+
+When you upload a model with orient-express and deploy it to a Vertex AI endpoint, the actual HTTP API exposed by the endpoint is determined by the serving container image — not by your Python predictor code. Orient-express ships two such images:
+
+- `image-onnx` — serves the built-in ONNX predictor types (classification, detection, segmentation).
+- `xgboost-scikit-learn` — serves any joblib-loadable model (sklearn pipelines, xgboost, etc.).
+
+This section documents the request/response shape each image's endpoint exposes once deployed.
+
+### How the docker images connect to GCP endpoints
+
+The deployment flow is:
+
+1. **Train + export.** You build a predictor locally (e.g. `ClassificationPredictor("model.onnx", classes)`) or train a sklearn/xgboost model.
+2. **Upload.** `upload_model` / `upload_model_joblib` pushes the artifacts to GCS under `gs://<bucket>/models/<model_name>/<version>/` and registers a Vertex AI Model with `serving_container_image_uri` pointing at one of orient-express's images.
+3. **Deploy.** `vertex_model.deploy_to_endpoint(...)` (or the Vertex console) attaches the registered model to a Vertex AI Endpoint. Vertex starts the container with `AIP_STORAGE_URI` set to the GCS path from step 2, plus `MODEL_NAME` set to the model's display name.
+4. **Serve.** The container downloads the artifacts on startup, instantiates the right predictor via metadata, and listens on `/v1/models/<MODEL_NAME>:predict`.
+5. **Call.** Clients POST to `https://<region>-aiplatform.googleapis.com/v1/projects/<project>/locations/<region>/endpoints/<endpoint_id>:predict` with a Bearer token. Vertex routes the request into the container and returns the JSON response.
+
+Every endpoint accepts the same envelope:
+
+```json
+{
+  "instances": [...],
+  "parameters": {...}
+}
+```
+
+What goes in `instances` / `parameters`, and what comes back in `predictions`, is per-image and per-predictor — covered below.
+
+### ONNX Image Endpoint
+
+Image: `us-west1-docker.pkg.dev/shiftsmart-api/orient-express/image-onnx:<tag>`
+
+Common request shape across all ONNX predictor types:
+
+```json
+{
+  "instances": [
+    {"image": "<http(s) URL | gs:// URI | base64 | data URI>"}
+  ],
+  "parameters": {
+    "confidence": 0.5
+  }
+}
+```
+
+Common response envelope:
+
+```json
+{
+  "predictions": [
+    {"status": "success", ...predictor-specific fields...}
+  ]
+}
+```
+
+`status` values: `"success"`, `"failed to download image"`, or `"failed to get debug image"`. Malformed payloads return top-level `{"error": "Failed to decode input"}` instead of `predictions`.
+
+The predictor-specific fields differ by model type — covered in the subsections below.
+
+#### Classification
+
+For models uploaded as `ClassificationPredictor`. `parameters.confidence` is **not** honored (the predictor always returns the top class).
+
+Per-image response:
+
+```json
+{
+  "status": "success",
+  "class": "cat",
+  "score": 0.95,
+  "class_scores": {"cat": 0.95, "dog": 0.03, "bird": 0.02}
+}
+```
+
+No `debug_image` for classification (nothing meaningful to draw).
+
+#### Multi-label classification
+
+For models uploaded as `MultiLabelClassificationPredictor`. `parameters.confidence` is the per-class threshold for inclusion in `classes` (default `0.5`).
+
+Per-image response:
+
+```json
+{
+  "status": "success",
+  "predictions": {
+    "classes": ["contains_cat", "contains_bird"],
+    "class_scores": {"contains_cat": 0.95, "contains_dog": 0.03, "contains_bird": 0.82}
+  },
+  "debug_image": null
+}
+```
+
+`debug_image` is always `null` for multi-label.
+
+#### Object detection
+
+For models uploaded as `BoundingBoxPredictor`. `parameters.confidence` filters detections below the threshold (default `0.5`).
+
+Per-image response:
+
+```json
+{
+  "status": "success",
+  "predictions": [
+    {"class": "person", "score": 0.92, "bbox": {"x1": 100.5, "y1": 50.2, "x2": 300.8, "y2": 400.1}}
+  ],
+  "debug_image": "<base64 JPEG with boxes overlaid>"
+}
+```
+
+`bbox` coordinates are in pixels of the original (EXIF-corrected) image. `predictions` is an empty list when nothing clears the confidence threshold.
+
+#### Instance segmentation
+
+For models uploaded as `InstanceSegmentationPredictor`. `parameters.confidence` filters detections (default `0.5`).
+
+Per-image response:
+
+```json
+{
+  "status": "success",
+  "predictions": [
+    {"class": "person", "score": 0.89, "bbox": {"x1": 100.5, "y1": 50.2, "x2": 300.8, "y2": 400.1}}
+  ],
+  "debug_image": "<base64 JPEG with masks overlaid>"
+}
+```
+
+Per-instance mask arrays are **not** included in the response by default (too large). The annotated mask overlay is baked into `debug_image`.
+
+#### Semantic segmentation
+
+For models uploaded as `SemanticSegmentationPredictor`. `parameters.confidence` is the per-pixel threshold above which a class is considered "valid" (default `0.5`).
+
+Per-image response:
+
+```json
+{
+  "status": "success",
+  "predictions": {
+    "class_mask": "<base64 PNG, uint8, per-pixel class id>",
+    "valid_mask": "<base64 PNG, uint8, 0=below threshold, 1=above>"
+  },
+  "debug_image": "<base64 JPEG with color-coded overlay>"
+}
+```
+
+`class_mask` always paints every pixel with the argmax winner. `valid_mask` tells you which pixels actually cleared the confidence threshold — AND them together client-side to get the "real" segmentation.
+
+### XGBoost / scikit-learn Endpoint
+
+Image: `us-west1-docker.pkg.dev/shiftsmart-api/orient-express/xgboost-scikit-learn:<tag>`
+
+For models uploaded via `upload_model_joblib` — sklearn pipelines, xgboost models, or anything `joblib.load`-able with a `.predict(DataFrame)` method.
+
+Request shape — `instances` is a list of dicts, one row per input:
+
+```json
+{
+  "instances": [
+    {"pclass": 1, "sex": "female", "age": 29, "fare": 100.0, "embarked": "S"},
+    {"pclass": 3, "sex": "male", "age": 35, "fare": 8.05, "embarked": "S"}
+  ]
+}
+```
+
+The server constructs `pd.DataFrame(instances)` and calls `model.predict(df)` on it. The columns your pipeline expects must be present in each instance dict.
+
+Response shape — one prediction per input row:
+
+```json
+{
+  "predictions": [0, 1]
+}
+```
+
+Each element is whatever your `.predict()` returns — a class label for classifiers, a numeric value for regressors, an array for multi-output models.
+
+`parameters` is ignored — there's no per-request configuration for this image.
+
+---
+
 ## Color Schemes
 
 For predictors that support annotation (`BoundingBoxPredictor`, `InstanceSegmentationPredictor`, `SemanticSegmentationPredictor`), you can set a custom color scheme:

--- a/docker-image-onnx/logging.conf
+++ b/docker-image-onnx/logging.conf
@@ -1,19 +1,16 @@
 
 [loggers]
-keys = root,custom,kserve
+keys = root,kserve
 
 [logger_root]
-handlers =
-
-[logger_custom]
 level = INFO
 handlers = custom
-qualname = custom
 
 [logger_kserve]
 level = INFO
 handlers = custom
 qualname = kserve
+propagate = 0
 
 [handlers]
 keys = custom

--- a/docker-image-onnx/run_inference_server.py
+++ b/docker-image-onnx/run_inference_server.py
@@ -126,16 +126,24 @@ class OnnxImageModel(Model):
     def download_image(self, image_address):
         if image_address.startswith("http"):
             # http url
+            logging.info(f"[{self.name}] image source: http url {image_address}")
             image = read_image_from_url(image_address)
         elif image_address.startswith("gs://"):
             # gs uri
+            logging.info(f"[{self.name}] image source: gcs uri {image_address}")
             image = read_image_from_gs(image_address)
         elif image_address.startswith("data:"):
             # data URI format: data:image/png;base64,iVBORw0KGgo...
             base64_data = image_address.split(",", 1)[1]
+            logging.info(
+                f"[{self.name}] image source: base64 data uri ({len(base64_data)} base64 chars)"
+            )
             image = base64_to_image(base64_data)
         else:
             # raw base64
+            logging.info(
+                f"[{self.name}] image source: raw base64 ({len(image_address)} base64 chars)"
+            )
             image = base64_to_image(image_address)
         return image
 

--- a/orient_express/predictors/predictor.py
+++ b/orient_express/predictors/predictor.py
@@ -46,7 +46,7 @@ class ImagePredictor(Predictor):
         self.model_path = model_path
 
     def get_serving_container_image_uri(self):
-        return "us-west1-docker.pkg.dev/shiftsmart-api/orient-express/image-onnx:v2.4.1"
+        return "us-west1-docker.pkg.dev/shiftsmart-api/orient-express/image-onnx:v2.4.2"
 
     def get_serving_container_health_route(self, model_name):
         return f"/v1/models/{model_name}"

--- a/orient_express/utils/image_processor.py
+++ b/orient_express/utils/image_processor.py
@@ -1,6 +1,9 @@
 import base64
+import ipaddress
 import logging
+import socket
 from io import BytesIO
+from urllib.parse import urlparse
 
 import cv2
 import numpy as np
@@ -8,6 +11,34 @@ from PIL import Image, ExifTags
 import requests
 
 from .gs import get_gcs_from_http_url, read_file_bytes
+
+DOWNLOAD_TIMEOUT_SECONDS = 30
+
+
+class UnsafeUrlError(ValueError):
+    pass
+
+
+def validate_url(http_url):
+    # Reject URLs that could be used for SSRF: the request runs server-side
+    # with the service account's network access, so only allow http(s) URLs
+    # that resolve to public IPs (blocks the GCE metadata server, localhost,
+    # and private/internal ranges).
+    parsed = urlparse(http_url)
+    if parsed.scheme not in ("http", "https"):
+        raise UnsafeUrlError(f"unsupported URL scheme: {parsed.scheme}")
+    if not parsed.hostname:
+        raise UnsafeUrlError("URL has no hostname")
+    try:
+        addr_infos = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror as e:
+        raise UnsafeUrlError(f"could not resolve host: {parsed.hostname}") from e
+    for addr_info in addr_infos:
+        ip = ipaddress.ip_address(addr_info[4][0])
+        if not ip.is_global:
+            raise UnsafeUrlError(
+                f"URL host {parsed.hostname} resolves to non-public address {ip}"
+            )
 
 
 def read_image_from_url(http_url, http_as_gcs=False) -> Image.Image:
@@ -19,7 +50,8 @@ def read_image_from_url(http_url, http_as_gcs=False) -> Image.Image:
         if gs_uri:
             return read_image_from_gs(gs_uri)
 
-    response = requests.get(http_url)
+    validate_url(http_url)
+    response = requests.get(http_url, timeout=DOWNLOAD_TIMEOUT_SECONDS)
     response.raise_for_status()
     image = Image.open(BytesIO(response.content))
     return image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orient_express"
-version = "2.4.1"
+version = "2.4.2"
 description = "A library to simplify model deployment to Vertex AI"
 authors = ["Alexey Zankevich <alex.zankevich@shiftsmart.com>", "Ian Myers <ian.myers@shiftsmart.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orient_express"
-version = "2.4.0"
+version = "2.4.1"
 description = "A library to simplify model deployment to Vertex AI"
 authors = ["Alexey Zankevich <alex.zankevich@shiftsmart.com>", "Ian Myers <ian.myers@shiftsmart.com>"]
 readme = "README.md"

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -1,0 +1,55 @@
+import pytest
+
+from orient_express.utils.image_processor import UnsafeUrlError, validate_url
+
+
+PUBLIC_ADDR_INFO = [(2, 1, 6, "", ("142.250.68.78", 0))]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://169.254.169.254/computeMetadata/v1/",
+        "http://127.0.0.1:8080/v1/models",
+        "http://localhost/foo.jpg",
+        "http://10.0.0.5/foo.jpg",
+        "http://192.168.1.1/foo.jpg",
+        "http://[::1]/foo.jpg",
+    ],
+)
+def test_validate_url_blocks_internal_addresses(url):
+    with pytest.raises(UnsafeUrlError):
+        validate_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "gopher://example.com/",
+        "ftp://example.com/foo.jpg",
+        "http://",
+    ],
+)
+def test_validate_url_blocks_bad_schemes_and_hosts(url):
+    with pytest.raises(UnsafeUrlError):
+        validate_url(url)
+
+
+def test_validate_url_allows_public_host(monkeypatch):
+    monkeypatch.setattr(
+        "orient_express.utils.image_processor.socket.getaddrinfo",
+        lambda host, port: PUBLIC_ADDR_INFO,
+    )
+    validate_url("https://storage.googleapis.com/some-bucket/image.jpg")
+
+
+def test_validate_url_blocks_host_resolving_to_metadata_ip(monkeypatch):
+    # DNS-level bypass: a public-looking hostname pointing at the metadata server
+    monkeypatch.setattr(
+        "orient_express.utils.image_processor.socket.getaddrinfo",
+        lambda host, port: [(2, 1, 6, "", ("169.254.169.254", 0))],
+    )
+    with pytest.raises(UnsafeUrlError):
+        validate_url("https://innocent-looking-domain.example.com/image.jpg")


### PR DESCRIPTION
  - image_processor: add validate_url() — reject non-http(s) schemes and any URL whose host resolves to a non-global IP (blocks the GCE metadata server, ocalhost, private ranges, and DNS-rebind to a link-local IP)
  - run_inference_server: log image source per request
  - logging.conf: attach stdout handler to the root logger so app-level INFO logs reach GCP (root previously had no handler); kserve propagate=0 to avoid duplicate lines.
  - bump image-onnx default serving image and version to v2.4.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive "Deployed Endpoint APIs" documentation describing request/response formats, deployment flows, and per-container image behaviors.

* **Bug Fixes**
  * Enhanced URL validation to prevent downloads from unsafe and private IP addresses.

* **Improvements**
  * Improved logging for image download source tracking.
  * Updated Docker container and package versions to v2.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->