### PR TITLE
Add private golden equivalence test suite

### DIFF
--- a/tests/equivalence/README.md
+++ b/tests/equivalence/README.md
@@ -1,0 +1,127 @@
+# Golden equivalence suite
+
+Runs real models on real photos and compares outputs against reviewed golden
+files, so any change that shifts model outputs is caught before merge — at
+two levels:
+
+- **Predictor level** (`test_equivalence.py`): the library in-process —
+  `get_predictor(model_dir)` → `predict(images)` → extracted outputs.
+- **Serving level** (`test_docker_equivalence.py`, opt-in): boots the actual
+  Docker serving image per case and checks the HTTP responses.
+
+Models, photos, and goldens are **private** — they live in a GCS prefix,
+never in this repo, and this code contains no references to specific models.
+The suite auto-skips unless configured, so public CI and external
+contributors never see it run.
+
+**Every run writes an HTML report** to `test-output/equivalence_report.html`:
+before/after annotated images per photo plus a per-field diff table of every
+comparison, including within-tolerance deltas (yellow rows). A test fails if
+and only if its image shows DIFFERS in the report. Always inspect the report
+before merging. It embeds internal photos — treat it as private; never
+publish or attach it anywhere public.
+
+## Environment variables
+
+| variable | required | meaning |
+|---|---|---|
+| `ORIENT_EXPRESS_TEST_MANIFEST` | yes | `gs://…/manifest.yaml` (or a local path). Without it, every test skips. |
+| `ORIENT_EXPRESS_TEST_DOCKER_IMAGE` | for serving tests | image tag to boot (usually built locally from your branch). |
+| `GOOGLE_CLOUD_PROJECT` | for serving tests | passed into the container so its GCS client can resolve a project (production Vertex provides this itself). |
+| `ORIENT_EXPRESS_TEST_GOLDENS_DIR` | no | local goldens dir instead of GCS — for evaluating **candidate** goldens before uploading. |
+| `ORIENT_EXPRESS_TEST_REPORT` | no | report output path (default `test-output/equivalence_report.html`). |
+| `ORIENT_EXPRESS_TEST_CACHE` | no | asset cache dir (default `~/.cache/orient-express-test-assets`). |
+
+GCP application-default credentials with read access to the prefix are
+required (`gcloud auth application-default login`).
+
+## Running (uv)
+
+```bash
+export ORIENT_EXPRESS_TEST_MANIFEST=gs://<internal-prefix>/manifest.yaml
+
+make equivalence          # predictor level + HTML report
+make equivalence-docker   # builds the local serving image, then both levels
+```
+
+Or directly: `uv run pytest tests/equivalence -v`. First run downloads the
+model artifacts (~100 MB per case) into the local cache; later runs reuse it.
+
+## Testing a feature branch — the full flow
+
+```bash
+make install                  # uv sync
+make lint                     # ruff check + format check (same as CI)
+make test                     # unit tests
+export ORIENT_EXPRESS_TEST_MANIFEST=gs://<internal-prefix>/manifest.yaml
+make equivalence              # golden gate + report
+# if the branch touches serving code, Dockerfiles, or dependencies:
+make equivalence-docker
+# then LOOK at test-output/equivalence_report.html before merging
+```
+
+## Golden lifecycle
+
+Goldens are the enshrined reference outputs. There is **no automated
+regeneration** — creating or replacing a golden is a deliberate, reviewed,
+manual act.
+
+> **No-take-back warning:** uploading goldens overwrites the previous
+> reference in place — there is no versioning and no undo. From that moment,
+> every branch is judged against the new goldens, and the old baseline is
+> gone unless you kept the local copy. Only upload after you have reviewed
+> the report and the golden files themselves, and keep the local directory
+> until you're certain.
+
+### 1. Generate candidates (locally only)
+
+```bash
+# predictor level (writes <case>.json + <case>/annotated/ images):
+uv run python tests/equivalence/generate_goldens.py --out /tmp/candidate-goldens
+
+# serving level (writes <case>.docker.json + <case>/docker-annotated/):
+# boot the reference server image against a case's model dir, then:
+uv run python tests/equivalence/generate_goldens.py --out /tmp/candidate-goldens \
+    --case <case> --docker-url http://localhost:8080
+```
+
+### 2. Review the candidates
+
+Run the suite against them and inspect the report — this shows exactly what
+would change relative to your current code:
+
+```bash
+ORIENT_EXPRESS_TEST_GOLDENS_DIR=/tmp/candidate-goldens uv run pytest tests/equivalence -v
+```
+
+Also open the golden JSONs and the `annotated/` JPEGs directly — they are
+the reference you're about to enshrine.
+
+### 3. Upload (the point of no return)
+
+```bash
+gcloud storage cp -r /tmp/candidate-goldens/* gs://<internal-prefix>/goldens/
+```
+
+### 4. Verify from GCS
+
+```bash
+unset ORIENT_EXPRESS_TEST_GOLDENS_DIR
+uv run pytest tests/equivalence -v
+```
+
+## Tolerances
+
+Comparison is tolerance-based, not bit-exact — BLAS/onnxruntime/pillow
+versions and OSes introduce float-level wiggle (score jitter across
+onnxruntime session boots and image dependency bumps is real and measured).
+Defaults live in `harness.DEFAULT_TOLERANCES`; the manifest can override per
+case, with comments documenting why. Class/argmax equality is always strict.
+Detection lists are matched order-independently (class + IoU): near-tied
+scores legitimately swap TopK order across onnxruntime versions.
+
+## Manifest
+
+See `manifest.example.yaml` for the structure. The real manifest lives next
+to the assets in GCS and defines the cases, predict-parameter variants,
+docker enablement, and tolerance overrides.

--- a/tests/equivalence/conftest.py
+++ b/tests/equivalence/conftest.py
@@ -1,0 +1,75 @@
+"""Fixtures for the golden equivalence suite.
+
+Everything here auto-skips unless ORIENT_EXPRESS_TEST_MANIFEST is set, so the
+suite is invisible to normal test runs, public CI, and external contributors.
+
+Every pytest run that executes at least one equivalence test writes an HTML
+report (before/after images + per-field diff tables) — by default to
+test-output/equivalence_report.html, overridable via
+ORIENT_EXPRESS_TEST_REPORT.
+"""
+
+import os
+
+import pytest
+
+from . import harness, htmlreport
+
+DEFAULT_REPORT_PATH = os.path.join("test-output", "equivalence_report.html")
+
+# case name -> {"blocks": [(title, html, failed)], "level": ...} accumulated
+# across tests, rendered at session end
+_collected: dict[str, list] = {}
+
+
+def pytest_collection_modifyitems(config, items):
+    if harness.manifest_location():
+        return
+    skip = pytest.mark.skip(
+        reason=f"{harness.MANIFEST_ENV} not set (private equivalence suite)"
+    )
+    for item in items:
+        if "equivalence" in str(item.fspath):
+            item.add_marker(skip)
+
+
+@pytest.fixture(scope="session")
+def manifest():
+    return harness.load_manifest()
+
+
+@pytest.fixture(scope="session")
+def docker_image():
+    image = os.environ.get(harness.DOCKER_IMAGE_ENV)
+    if not image:
+        pytest.skip(f"{harness.DOCKER_IMAGE_ENV} not set")
+    return image
+
+
+def collect_image_block(
+    section: str, title, records, before=None, after=None, captions=None
+):
+    """Called by tests to feed the end-of-session HTML report."""
+    block_html, failed = htmlreport.image_block(title, records, before, after, captions)
+    _collected.setdefault(section, []).append((block_html, failed))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if not _collected:
+        return
+    sections = []
+    for section_name in sorted(_collected):
+        blocks = _collected[section_name]
+        fail = sum(1 for _, failed in blocks if failed)
+        ok = len(blocks) - fail
+        section_html = f"<h2>{section_name}</h2>" + "".join(b for b, _ in blocks)
+        sections.append((section_name, section_html, ok, fail))
+    page = htmlreport.build_page(sections, harness.provenance())
+    path = os.environ.get(harness.REPORT_ENV, DEFAULT_REPORT_PATH)
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(page)
+    print(f"\nequivalence report: {path} ({os.path.getsize(path) / 1e6:.1f} MB)")
+    _collected.clear()

--- a/tests/equivalence/generate_goldens.py
+++ b/tests/equivalence/generate_goldens.py
@@ -1,0 +1,151 @@
+"""Generate golden files for the equivalence suite.
+
+Writes ONLY to a local directory — uploading goldens to GCS is a deliberate,
+manually-reviewed act (there is no automated regeneration):
+
+    python tests/equivalence/generate_goldens.py --out /tmp/goldens
+    # review the JSON + annotated images, then:
+    # gcloud storage cp -r /tmp/goldens/* <prefix>/goldens/
+
+Alongside each <case>.json this writes <case>/annotated/<variant>/<image>.jpg
+(the golden code's rendering of its own predictions) for the HTML report's
+before/after view.
+
+Serving-level goldens are captured from a running container (boot it
+yourself against the case's model dir):
+
+    python tests/equivalence/generate_goldens.py --out /tmp/goldens \
+        --case <case> --docker-url http://localhost:8080
+
+Requests are sent one image per call (fixed-batch-1 graphs; matches
+production traffic shape).
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # tests/
+
+from equivalence import harness  # noqa: E402
+
+
+def generate_predictor_golden(manifest, case, out_dir):
+    case_cfg = manifest["cases"][case]
+    case_dir = harness.fetch_case_assets(manifest, case)
+
+    if "query_case" in case_cfg:
+        query_dir = harness.fetch_case_assets(manifest, case_cfg["query_case"])
+        query_predictor = harness.load_case_predictor(query_dir)
+        query_outputs = harness.extract_outputs(
+            query_predictor,
+            harness.case_model_type(query_dir),
+            harness.load_case_images(query_dir),
+            {},
+        )
+        embeddings = {k: v["embedding"] for k, v in query_outputs.items()}
+        index = harness.load_case_predictor(case_dir)
+        outputs = harness.run_vector_index_case(
+            index, embeddings, case_cfg.get("top_k", 5)
+        )
+        return {
+            "case": case,
+            "generated_by": harness.provenance(),
+            "variants": {"default": outputs},
+        }
+
+    predictor = harness.load_case_predictor(case_dir)
+    model_type = harness.case_model_type(case_dir)
+    images = harness.load_case_images(case_dir)
+    variants = {}
+    for variant in harness.case_variants(case_cfg):
+        params = variant.get("predict_params", {})
+        variants[variant["name"]] = harness.extract_outputs(
+            predictor, model_type, images, params
+        )
+        annotated = harness.render_annotated(predictor, model_type, images, params)
+        for image_name, jpeg in annotated.items():
+            if jpeg is None:
+                continue
+            path = os.path.join(
+                out_dir, case, "annotated", variant["name"], f"{image_name}.jpg"
+            )
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "wb") as f:
+                f.write(jpeg)
+    return {"case": case, "generated_by": harness.provenance(), "variants": variants}
+
+
+def generate_docker_golden(manifest, case, server_url, out_dir):
+    import requests
+
+    case_cfg = manifest["cases"][case]
+    case_dir = harness.fetch_case_assets(manifest, case)
+    images_dir = os.path.join(case_dir, "images")
+
+    variants = {}
+    for variant in harness.case_variants(case_cfg):
+        by_image = {}
+        for name in sorted(os.listdir(images_dir)):
+            with open(os.path.join(images_dir, name), "rb") as f:
+                instance = {"image": base64.b64encode(f.read()).decode()}
+            payload = {
+                "instances": [instance],
+                "parameters": variant.get("predict_params", {}),
+            }
+            response = requests.post(
+                f"{server_url}/v1/models/{case}:predict", json=payload, timeout=600
+            )
+            response.raise_for_status()
+            prediction = response.json()["predictions"][0]
+            # stripped from the JSON (huge), but kept as sibling files for the
+            # HTML report's before/after view
+            debug_b64 = prediction.pop("debug_image", None)
+            if debug_b64:
+                path = os.path.join(
+                    out_dir, case, "docker-annotated", variant["name"], f"{name}.jpg"
+                )
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "wb") as f:
+                    f.write(base64.b64decode(debug_b64))
+            by_image[name] = prediction
+        variants[variant["name"]] = by_image
+    return {"case": case, "generated_by": harness.provenance(), "variants": variants}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True, help="local output directory")
+    parser.add_argument("--case", action="append", help="subset of cases (default all)")
+    parser.add_argument("--docker-url", help="capture serving goldens from this URL")
+    args = parser.parse_args()
+
+    manifest = harness.load_manifest()
+    cases = args.case or sorted(manifest["cases"].keys())
+    os.makedirs(args.out, exist_ok=True)
+
+    for case in cases:
+        if args.docker_url:
+            if not manifest["cases"][case].get("docker", False):
+                print(f"{case}: docker disabled in manifest, skipping")
+                continue
+            golden = generate_docker_golden(manifest, case, args.docker_url, args.out)
+            path = os.path.join(args.out, f"{case}.docker.json")
+        else:
+            golden = generate_predictor_golden(manifest, case, args.out)
+            path = os.path.join(args.out, f"{case}.json")
+        with open(path, "w") as f:
+            json.dump(golden, f, indent=1, sort_keys=True)
+        print(
+            f"{case}: wrote {path} ({os.path.getsize(path) / 1024:.0f} KiB, "
+            f"digest {harness.stable_digest(golden['variants'])})"
+        )
+
+    print("\nReview the files, then upload manually:")
+    print(f"  gcloud storage cp -r {args.out}/* {manifest['gcs_prefix']}/goldens/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/equivalence/harness.py
+++ b/tests/equivalence/harness.py
@@ -1,0 +1,605 @@
+"""Core of the golden equivalence suite.
+
+Version-agnostic on purpose: this module must run unmodified against both the
+pre-refactor (2.4.x) and current APIs, because goldens are generated on the
+old code and enforced on every branch after it. Keep imports and predictor
+interactions to surface area that exists in both.
+
+Prediction always runs one image per predict() call: some deployed ONNX
+graphs have a fixed batch dimension of 1, and per-image calls match how the
+production pipelines and Vertex endpoints invoke the models.
+"""
+
+import hashlib
+import io
+import json
+import os
+import platform
+import subprocess
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+
+import numpy as np
+import yaml
+from PIL import Image
+
+MANIFEST_ENV = "ORIENT_EXPRESS_TEST_MANIFEST"
+DOCKER_IMAGE_ENV = "ORIENT_EXPRESS_TEST_DOCKER_IMAGE"
+GOLDENS_DIR_ENV = "ORIENT_EXPRESS_TEST_GOLDENS_DIR"  # local override (else GCS)
+REPORT_ENV = "ORIENT_EXPRESS_TEST_REPORT"  # report path override
+
+DEFAULT_TOLERANCES = {
+    "score_atol": 1e-3,
+    "bbox_atol": 0.5,
+    "mask_iou_min": 0.999,
+    "pixel_mismatch_max": 1e-4,
+    "cosine_min": 0.9999,
+    "class_scores_atol": 1e-3,
+}
+
+
+# ----------------------------------------------------------------- manifest
+
+
+def manifest_location() -> str | None:
+    return os.environ.get(MANIFEST_ENV)
+
+
+def cache_root() -> str:
+    return os.environ.get(
+        "ORIENT_EXPRESS_TEST_CACHE",
+        os.path.join(os.path.expanduser("~"), ".cache", "orient-express-test-assets"),
+    )
+
+
+def _read_gcs_text(gs_url: str) -> str:
+    from google.cloud import storage
+
+    bucket_name, path = gs_url.replace("gs://", "").split("/", 1)
+    client = storage.Client()
+    return client.bucket(bucket_name).blob(path).download_as_text()
+
+
+def load_manifest() -> dict:
+    location = manifest_location()
+    if location is None:
+        raise RuntimeError(f"{MANIFEST_ENV} is not set")
+    if location.startswith("gs://"):
+        text = _read_gcs_text(location)
+    else:
+        with open(location) as f:
+            text = f.read()
+    manifest = yaml.safe_load(text)
+    manifest.setdefault("default_tolerances", {})
+    return manifest
+
+
+def case_tolerances(manifest: dict, case_cfg: dict) -> dict:
+    tolerances = dict(DEFAULT_TOLERANCES)
+    tolerances.update(manifest.get("default_tolerances", {}))
+    tolerances.update(case_cfg.get("tolerances", {}))
+    return tolerances
+
+
+def case_variants(case_cfg: dict) -> list[dict]:
+    return case_cfg.get("variants", [{"name": "default", "predict_params": {}}])
+
+
+def fetch_prefix(gs_prefix: str, local_dir: str):
+    """Download every blob under gs_prefix into local_dir (skip existing)."""
+    from google.cloud import storage
+
+    bucket_name, prefix = gs_prefix.replace("gs://", "").split("/", 1)
+    prefix = prefix.rstrip("/") + "/"
+    client = storage.Client()
+    os.makedirs(local_dir, exist_ok=True)
+    found = False
+    for blob in client.bucket(bucket_name).list_blobs(prefix=prefix):
+        relative = blob.name[len(prefix) :]
+        if not relative:
+            continue
+        found = True
+        destination = os.path.join(local_dir, relative)
+        if os.path.exists(destination) and os.path.getsize(destination) == blob.size:
+            continue
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        blob.download_to_filename(destination)
+    if not found:
+        raise FileNotFoundError(f"no blobs under {gs_prefix}")
+
+
+def fetch_case_assets(manifest: dict, case: str) -> str:
+    """Download cases/<case>/{model,images} to the local cache; return dir."""
+    case_dir = os.path.join(cache_root(), "cases", case)
+    fetch_prefix(f"{manifest['gcs_prefix']}/cases/{case}", case_dir)
+    return case_dir
+
+
+def fetch_golden(manifest: dict, name: str, goldens_dir: str | None = None):
+    """Load a golden JSON from a local dir (if given) or the GCS prefix."""
+    if goldens_dir is None:
+        goldens_dir = os.environ.get(GOLDENS_DIR_ENV)
+    if goldens_dir is not None:
+        path = os.path.join(goldens_dir, f"{name}.json")
+        if not os.path.exists(path):
+            return None
+        with open(path) as f:
+            return json.load(f)
+    try:
+        text = _read_gcs_text(f"{manifest['gcs_prefix']}/goldens/{name}.json")
+    except Exception:
+        return None
+    return json.loads(text)
+
+
+def golden_annotated_dir(
+    manifest: dict, case: str, goldens_dir: str | None = None, kind: str = "annotated"
+) -> str | None:
+    """Local dir holding the golden's annotated images (fetched if remote).
+
+    kind: "annotated" (predictor level) or "docker-annotated" (serving level).
+    """
+    if goldens_dir is None:
+        goldens_dir = os.environ.get(GOLDENS_DIR_ENV)
+    if goldens_dir is not None:
+        path = os.path.join(goldens_dir, case, kind)
+        return path if os.path.isdir(path) else None
+    local = os.path.join(cache_root(), "goldens", case, kind)
+    try:
+        fetch_prefix(f"{manifest['gcs_prefix']}/goldens/{case}/{kind}", local)
+    except FileNotFoundError:
+        return None
+    return local
+
+
+# ------------------------------------------------------------ case running
+
+
+def load_case_images(case_dir: str) -> dict[str, Image.Image]:
+    images_dir = os.path.join(case_dir, "images")
+    images = {}
+    if not os.path.isdir(images_dir):
+        return images
+    for name in sorted(os.listdir(images_dir)):
+        if name.lower().endswith((".jpg", ".jpeg", ".png")):
+            images[name] = Image.open(os.path.join(images_dir, name)).convert("RGB")
+    return images
+
+
+def load_case_predictor(case_dir: str):
+    from orient_express.predictors import get_predictor
+
+    return get_predictor(os.path.join(case_dir, "model"))
+
+
+def case_model_type(case_dir: str) -> str:
+    with open(os.path.join(case_dir, "model", "metadata.yaml")) as f:
+        return yaml.safe_load(f)["model_type"]
+
+
+def rle_encode(mask: np.ndarray) -> dict:
+    """Run-length encode a boolean mask (row-major, starting with False runs)."""
+    flat = np.asarray(mask, dtype=bool).ravel()
+    if flat.size == 0:
+        return {"shape": list(mask.shape), "counts": []}
+    changes = np.flatnonzero(flat[1:] != flat[:-1]) + 1
+    boundaries = np.concatenate([[0], changes, [flat.size]])
+    counts = np.diff(boundaries).tolist()
+    if flat[0]:
+        counts = [0] + counts
+    return {"shape": list(mask.shape), "counts": counts}
+
+
+def rle_decode(encoded: dict) -> np.ndarray:
+    total = int(np.prod(encoded["shape"])) if encoded["shape"] else 0
+    flat = np.zeros(total, dtype=bool)
+    position = 0
+    value = False
+    for count in encoded["counts"]:
+        if value:
+            flat[position : position + count] = True
+        position += count
+        value = not value
+    return flat.reshape(encoded["shape"])
+
+
+def _full_res_mask(prediction, image: Image.Image) -> np.ndarray:
+    """Instance-seg mask at image resolution, across library versions."""
+    if hasattr(prediction, "resized_mask"):  # >= 3.0: model-res mask + resize
+        return prediction.resized_mask(image)
+    return np.asarray(prediction.mask, dtype=bool)  # <= 2.4.x: already full-res
+
+
+def _predict_one(predictor, image: Image.Image, predict_params: dict):
+    """One image per call: fixed-batch-1 graphs + production traffic shape."""
+    return predictor.predict([image], **predict_params)[0]
+
+
+def evaluate_variant(
+    predictor, model_type: str, images, predict_params: dict, annotate: bool = True
+):
+    """Predict once per image; return (outputs, annotated JPEG bytes or None)."""
+    outputs = {}
+    annotated = {}
+    for name, image in images.items():
+        pred = _predict_one(predictor, image, predict_params)
+        outputs[name] = _extract_prediction(pred, model_type, image)
+        if annotate and model_type in ANNOTATABLE_TYPES:
+            rendered = predictor.get_annotated_image(image, pred)
+            buffer = io.BytesIO()
+            rendered.convert("RGB").save(buffer, format="JPEG", quality=85)
+            annotated[name] = buffer.getvalue()
+        else:
+            annotated[name] = None
+    return outputs, annotated
+
+
+def extract_outputs(predictor, model_type: str, images, predict_params: dict):
+    """Run predict per image and reduce results to version-agnostic JSON."""
+    return evaluate_variant(
+        predictor, model_type, images, predict_params, annotate=False
+    )[0]
+
+
+def _extract_prediction(pred, model_type: str, image):
+    if model_type == "classification-onnx":
+        return {
+            "class": pred.clss,
+            "score": float(pred.score),
+            "class_scores": {k: float(v) for k, v in pred.class_scores.items()},
+        }
+    if model_type == "multi-label-classification-onnx":
+        return {
+            "classes": sorted(pred.classes),
+            "class_scores": {k: float(v) for k, v in pred.class_scores.items()},
+        }
+    if model_type == "object-detection-onnx":
+        return {
+            "detections": [
+                {
+                    "class": d.clss,
+                    "score": float(d.score),
+                    "bbox": [float(v) for v in d.bbox],
+                }
+                for d in pred
+            ]
+        }
+    if model_type == "instance-segmentation-onnx":
+        return {
+            "detections": [
+                {
+                    "class": d.clss,
+                    "score": float(d.score),
+                    "bbox": [float(v) for v in d.bbox],
+                    "mask_rle": rle_encode(_full_res_mask(d, image)),
+                }
+                for d in pred
+            ]
+        }
+    if model_type == "semantic-segmentation-onnx":
+        return {
+            "class_mask_rle_per_class": {
+                str(class_id): rle_encode(pred.class_mask == class_id)
+                for class_id in np.unique(pred.class_mask).tolist()
+            },
+            "valid_mask_rle": rle_encode(np.asarray(pred.valid_mask, dtype=bool)),
+        }
+    if model_type == "feature-extraction-onnx":
+        return {"embedding": [float(v) for v in np.ravel(pred.feature)]}
+    raise ValueError(f"no extractor for model_type '{model_type}'")
+
+
+ANNOTATABLE_TYPES = {
+    "object-detection-onnx",
+    "instance-segmentation-onnx",
+    "semantic-segmentation-onnx",
+}
+
+
+def render_annotated(predictor, model_type: str, images, predict_params: dict):
+    """Annotated JPEG bytes per image (None-valued for non-visual models)."""
+    return evaluate_variant(predictor, model_type, images, predict_params)[1]
+
+
+def _plain_labels(labels):
+    if isinstance(labels, (list, tuple)):
+        return list(labels)
+    return labels
+
+
+def run_vector_index_case(index, query_embeddings: dict, top_k: int):
+    """query_embeddings: image name -> embedding list (from another case)."""
+    outputs = {}
+    for name, embedding in query_embeddings.items():
+        query = np.asarray(embedding, dtype=np.float32)
+        norm = np.linalg.norm(query)
+        if norm > 0:
+            query = query / norm
+        results = index.search(query, k=top_k)
+        outputs[name] = {
+            "results": [
+                {"labels": _plain_labels(r.labels), "score": float(r.score)}
+                for r in results
+            ]
+        }
+    return outputs
+
+
+# -------------------------------------------------------------- comparison
+
+
+def _mask_iou(a: np.ndarray, b: np.ndarray) -> float:
+    if a.shape != b.shape:
+        return 0.0
+    union = np.logical_or(a, b).sum()
+    if union == 0:
+        return 1.0
+    return float(np.logical_and(a, b).sum() / union)
+
+
+def _record(records, field, golden, got, ok, detail=""):
+    records.append(
+        {"field": field, "golden": golden, "got": got, "ok": bool(ok), "detail": detail}
+    )
+
+
+def compare_outputs(got: dict, golden: dict, tolerances: dict) -> list[dict]:
+    """Compare per-image outputs; returns structured records (passing + failing).
+
+    Record fields: field (path-like), golden, got, ok, detail. The failing
+    subset is what gates the tests; the full set feeds the HTML report.
+    """
+    records = []
+    for name in golden:
+        if name not in got:
+            _record(records, name, "present", "missing", False)
+            continue
+        for r in _compare_image(got[name], golden[name], tolerances):
+            r["field"] = f"{name}: {r['field']}"
+            records.append(r)
+    for name in got:
+        if name not in golden:
+            _record(records, name, "absent", "present", False, "not in golden")
+    return records
+
+
+def failures(records: list[dict]) -> list[str]:
+    return [
+        f"{r['field']}: golden={r['golden']} got={r['got']} {r['detail']}".strip()
+        for r in records
+        if not r["ok"]
+    ]
+
+
+def _bbox_iou(a, b) -> float:
+    x1, y1 = max(a[0], b[0]), max(a[1], b[1])
+    x2, y2 = min(a[2], b[2]), min(a[3], b[3])
+    inter = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    area_a = (a[2] - a[0]) * (a[3] - a[1])
+    area_b = (b[2] - b[0]) * (b[3] - b[1])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _match_detections(expected: list, actual: list) -> list[tuple]:
+    """Greedy order-independent matching (same class, best IoU >= 0.5).
+
+    Detection order is not part of the semantic contract: near-tied scores
+    (deltas ~1e-6) swap TopK order across onnxruntime versions.
+    """
+    pairs = []
+    used = set()
+    for i, g in enumerate(expected):
+        best, best_iou = None, 0.5
+        for j, a in enumerate(actual):
+            if j in used or a["class"] != g["class"]:
+                continue
+            iou = _bbox_iou(g["bbox"], a["bbox"])
+            if iou >= best_iou:
+                best, best_iou = j, iou
+        if best is not None:
+            used.add(best)
+            pairs.append((i, g, actual[best]))
+    return pairs
+
+
+def _compare_image(got: dict, golden: dict, tol: dict) -> list[dict]:
+    records = []
+    if "detections" in golden:
+        expected, actual = golden["detections"], got.get("detections", [])
+        _record(
+            records,
+            "detection count",
+            len(expected),
+            len(actual),
+            len(actual) == len(expected),
+        )
+        if len(actual) != len(expected):
+            return records
+        pairs = _match_detections(expected, actual)
+        _record(
+            records,
+            "detections matched (class + IoU)",
+            len(expected),
+            len(pairs),
+            len(pairs) == len(expected),
+        )
+        for i, g, a in pairs:
+            score_delta = abs(a["score"] - g["score"])
+            _record(
+                records,
+                f"det[{i}].score",
+                round(g["score"], 5),
+                round(a["score"], 5),
+                score_delta <= tol["score_atol"],
+                f"Δ{score_delta:.2e} (tol {tol['score_atol']})",
+            )
+            box_delta = max(
+                abs(x - y) for x, y in zip(a["bbox"], g["bbox"], strict=True)
+            )
+            _record(
+                records,
+                f"det[{i}].bbox",
+                [round(v, 1) for v in g["bbox"]],
+                [round(v, 1) for v in a["bbox"]],
+                box_delta <= tol["bbox_atol"],
+                f"maxΔ{box_delta:.3f}px (tol {tol['bbox_atol']})",
+            )
+            if "mask_rle" in g:
+                iou = _mask_iou(rle_decode(a["mask_rle"]), rle_decode(g["mask_rle"]))
+                _record(
+                    records,
+                    f"det[{i}].mask",
+                    "—",
+                    f"IoU {iou:.6f}",
+                    iou >= tol["mask_iou_min"],
+                    f"(min {tol['mask_iou_min']})",
+                )
+    if "class" in golden:
+        _record(
+            records,
+            "class",
+            golden["class"],
+            got.get("class"),
+            got.get("class") == golden["class"],
+        )
+        delta = abs(got.get("score", 0) - golden["score"])
+        _record(
+            records,
+            "score",
+            round(golden["score"], 5),
+            round(got.get("score", 0), 5),
+            delta <= tol["score_atol"],
+            f"Δ{delta:.2e}",
+        )
+    if "classes" in golden:  # multi-label
+        same = sorted(got.get("classes", [])) == sorted(golden["classes"])
+        _record(records, "classes", golden["classes"], got.get("classes"), same)
+    if "class_scores" in golden:
+        worst_key, worst_delta = None, -1.0
+        ok = True
+        for key, expected in golden["class_scores"].items():
+            actual = got.get("class_scores", {}).get(key)
+            if actual is None:
+                ok = False
+                worst_key, worst_delta = key, float("inf")
+                break
+            delta = abs(actual - expected)
+            if delta > worst_delta:
+                worst_key, worst_delta = key, delta
+            if delta > tol["class_scores_atol"]:
+                ok = False
+        _record(
+            records,
+            "class_scores",
+            "—",
+            f"worst Δ{worst_delta:.2e} [{worst_key}]",
+            ok,
+            f"(tol {tol['class_scores_atol']})",
+        )
+    if "class_mask_rle_per_class" in golden:
+        for class_id, encoded in golden["class_mask_rle_per_class"].items():
+            expected_mask = rle_decode(encoded)
+            actual_encoded = got.get("class_mask_rle_per_class", {}).get(class_id)
+            actual_mask = (
+                rle_decode(actual_encoded)
+                if actual_encoded
+                else np.zeros(expected_mask.shape, dtype=bool)
+            )
+            mismatch = float(np.mean(expected_mask != actual_mask))
+            _record(
+                records,
+                f"class_mask[{class_id}]",
+                "—",
+                f"pixel mismatch {mismatch:.2e}",
+                mismatch <= tol["pixel_mismatch_max"],
+                f"(max {tol['pixel_mismatch_max']})",
+            )
+    if "valid_mask_rle" in golden:
+        mismatch = float(
+            np.mean(
+                rle_decode(got["valid_mask_rle"])
+                != rle_decode(golden["valid_mask_rle"])
+            )
+        )
+        _record(
+            records,
+            "valid_mask",
+            "—",
+            f"pixel mismatch {mismatch:.2e}",
+            mismatch <= tol["pixel_mismatch_max"],
+        )
+    if "embedding" in golden:
+        expected = np.asarray(golden["embedding"], dtype=np.float64)
+        actual = np.asarray(got.get("embedding", []), dtype=np.float64)
+        if actual.shape != expected.shape:
+            _record(
+                records,
+                "embedding",
+                list(expected.shape),
+                list(actual.shape),
+                False,
+                "shape mismatch",
+            )
+        else:
+            denominator = np.linalg.norm(actual) * np.linalg.norm(expected)
+            cosine = float(actual @ expected / denominator) if denominator else 1.0
+            _record(
+                records,
+                "embedding",
+                "—",
+                f"cosine {cosine:.6f}",
+                cosine >= tol["cosine_min"],
+                f"(min {tol['cosine_min']})",
+            )
+    if "results" in golden:  # vector index
+        expected, actual = golden["results"], got.get("results", [])
+        same_labels = [r["labels"] for r in actual] == [r["labels"] for r in expected]
+        _record(
+            records,
+            "top-k labels",
+            [r["labels"] for r in expected],
+            [r["labels"] for r in actual],
+            same_labels,
+        )
+        if same_labels:
+            for i, (g, a) in enumerate(zip(expected, actual, strict=True)):
+                delta = abs(a["score"] - g["score"])
+                _record(
+                    records,
+                    f"result[{i}].score",
+                    round(g["score"], 5),
+                    round(a["score"], 5),
+                    delta <= tol["score_atol"],
+                    f"Δ{delta:.2e}",
+                )
+    return records
+
+
+# ------------------------------------------------------------- provenance
+
+
+def provenance() -> dict:
+    try:
+        library_version = package_version("orient_express")
+    except PackageNotFoundError:
+        library_version = "unknown"
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:
+        commit = "unknown"
+    return {
+        "library_version": library_version,
+        "git_commit": commit,
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+    }
+
+
+def stable_digest(payload) -> str:
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()[:16]

--- a/tests/equivalence/htmlreport.py
+++ b/tests/equivalence/htmlreport.py
@@ -1,0 +1,111 @@
+"""HTML rendering for the equivalence report.
+
+Pure functions over collected results — used both by the pytest session
+(report emitted automatically at the end of a run) and by the standalone
+report.py. The output embeds internal photos; treat it as private.
+"""
+
+import base64
+import html
+
+STYLE = """
+body { font-family: system-ui, sans-serif; margin: 2rem; background: #fafafa; }
+h1 { font-size: 1.4rem; } h2 { font-size: 1.15rem; margin-top: 2.5rem;
+border-bottom: 2px solid #ddd; padding-bottom: .3rem; }
+h3 { font-size: 1rem; margin-top: 1.5rem; }
+.summary { border-collapse: collapse; margin: 1rem 0; }
+.summary td, .summary th { border: 1px solid #ccc; padding: .35rem .7rem; }
+.imgpair { display: flex; gap: 1rem; margin: .5rem 0; }
+.imgpair figure { margin: 0; }
+.imgpair img { max-width: 460px; max-height: 460px; border: 1px solid #bbb; }
+figcaption { font-size: .8rem; color: #555; text-align: center; }
+table.diff { border-collapse: collapse; font-size: .82rem; margin: .4rem 0 1.4rem; }
+table.diff td, table.diff th { border: 1px solid #ddd; padding: .25rem .55rem;
+text-align: left; }
+tr.fail { background: #ffe3e3; font-weight: 600; }
+tr.ok-delta { background: #fff8dc; }
+.pass { color: #1a7f37; font-weight: 600; } .fail { color: #c0392b; font-weight: 700; }
+.meta { color: #666; font-size: .85rem; }
+"""
+
+
+def img_tag(jpeg_bytes, caption):
+    if jpeg_bytes is None:
+        return ""
+    encoded = base64.b64encode(jpeg_bytes).decode()
+    return (
+        f'<figure><img src="data:image/jpeg;base64,{encoded}">'
+        f"<figcaption>{html.escape(caption)}</figcaption></figure>"
+    )
+
+
+def diff_table(records):
+    rows = []
+    for r in records:
+        css = "fail" if not r["ok"] else ("ok-delta" if "Δ" in str(r["detail"]) else "")
+        status = "FAIL" if not r["ok"] else "ok"
+        rows.append(
+            f'<tr class="{css}"><td>{html.escape(str(r["field"]))}</td>'
+            f"<td>{html.escape(str(r['golden']))}</td>"
+            f"<td>{html.escape(str(r['got']))}</td>"
+            f"<td>{html.escape(str(r['detail']))}</td>"
+            f"<td>{status}</td></tr>"
+        )
+    return (
+        '<table class="diff"><tr><th>field</th><th>golden (before)</th>'
+        "<th>current (after)</th><th>detail</th><th>status</th></tr>"
+        + "".join(rows)
+        + "</table>"
+    )
+
+
+def image_block(title, records, before_jpeg=None, after_jpeg=None, captions=None):
+    """One image's section: status header, before/after pair, diff table."""
+    failed = any(not r["ok"] for r in records)
+    status = (
+        '<span class="fail">DIFFERS</span>'
+        if failed
+        else '<span class="pass">equivalent</span>'
+    )
+    parts = [f"<h4>{html.escape(title)} — {status}</h4>"]
+    if before_jpeg or after_jpeg:
+        before_caption, after_caption = captions or (
+            "before (golden)",
+            "after (current)",
+        )
+        parts.append(
+            '<div class="imgpair">'
+            + img_tag(before_jpeg, before_caption)
+            + img_tag(after_jpeg, after_caption)
+            + "</div>"
+        )
+    parts.append(diff_table(records))
+    return "".join(parts), failed
+
+
+def build_page(case_sections, current_provenance):
+    """case_sections: list of (case_name, html, ok_count, fail_count)."""
+    summary_rows = []
+    body = []
+    for case_name, section_html, ok, fail in case_sections:
+        verdict = (
+            '<span class="pass">equivalent</span>'
+            if fail == 0
+            else f'<span class="fail">{fail} differ</span>'
+        )
+        summary_rows.append(
+            f"<tr><td>{html.escape(case_name)}</td><td>{ok}</td>"
+            f"<td>{fail}</td><td>{verdict}</td></tr>"
+        )
+        body.append(section_html)
+    return f"""<!doctype html><meta charset="utf-8">
+<title>orient-express equivalence report</title>
+<style>{STYLE}</style>
+<h1>Equivalence report — current vs golden</h1>
+<p class="meta">current code: {html.escape(str(current_provenance.get("library_version")))} @
+{html.escape(str(current_provenance.get("git_commit")))} on
+{html.escape(str(current_provenance.get("platform")))}</p>
+<table class="summary"><tr><th>case</th><th>images equivalent</th>
+<th>images differing</th><th>verdict</th></tr>{"".join(summary_rows)}</table>
+{"".join(body)}
+"""

--- a/tests/equivalence/manifest.example.yaml
+++ b/tests/equivalence/manifest.example.yaml
@@ -1,0 +1,38 @@
+# Example manifest (the real one lives in the private GCS prefix).
+#
+# Layout under gcs_prefix:
+#   manifest.yaml
+#   cases/<case>/model/   (metadata.yaml + model artifact — a pinned copy)
+#   cases/<case>/images/  (numbered photos: 00.jpg, 01.jpg, ...)
+#   goldens/<case>.json
+#   goldens/<case>.docker.json
+
+gcs_prefix: gs://example-bucket/example-prefix
+
+# Tolerances may be overridden per case.
+default_tolerances:
+  score_atol: 1.0e-3      # per-score absolute tolerance
+  bbox_atol: 0.5          # box coordinate tolerance, pixels
+  mask_iou_min: 0.999     # thresholded-mask IoU vs golden
+  pixel_mismatch_max: 1.0e-4  # semantic masks: fraction of differing pixels
+  cosine_min: 0.9999      # embeddings
+  class_scores_atol: 1.0e-3
+
+cases:
+  example-detection:
+    docker: true
+    variants:
+      - name: default
+        predict_params: {confidence: 0.5}
+      - name: nms
+        predict_params: {confidence: 0.5, nms_threshold: 0.5}
+  example-classification:
+    docker: true
+    variants:
+      - name: default
+        predict_params: {}
+  example-vector-index:
+    docker: false
+    # queries come from another case's embeddings (deterministic chain)
+    query_case: example-feature-extraction
+    top_k: 5

--- a/tests/equivalence/test_docker_equivalence.py
+++ b/tests/equivalence/test_docker_equivalence.py
@@ -1,0 +1,268 @@
+"""Serving-level golden equivalence: boots the serving container per case and
+compares HTTP responses against docker goldens.
+
+Opt-in: requires ORIENT_EXPRESS_TEST_DOCKER_IMAGE (an image tag, usually built
+locally from the branch under test) in addition to the manifest env var.
+"""
+
+import base64
+import io
+import os
+import subprocess
+import time
+
+import numpy as np
+import pytest
+import requests
+from PIL import Image
+
+from . import harness
+from .conftest import collect_image_block
+
+HOST_PORT = int(os.environ.get("ORIENT_EXPRESS_TEST_DOCKER_PORT", "18093"))
+ADC_PATH = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
+
+
+def _docker_cases():
+    if not harness.manifest_location():
+        return []
+    manifest = harness.load_manifest()
+    return sorted(
+        case for case, cfg in manifest["cases"].items() if cfg.get("docker", False)
+    )
+
+
+def _start_container(image: str, manifest: dict, case: str) -> str:
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-v",
+            f"{ADC_PATH}:/root/.config/gcloud/application_default_credentials.json:ro",
+            "-e",
+            "GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json",
+            "-e",
+            f"GOOGLE_CLOUD_PROJECT={os.environ.get('GOOGLE_CLOUD_PROJECT', '')}",
+            "-e",
+            f"AIP_STORAGE_URI={manifest['gcs_prefix']}/cases/{case}/model/",
+            "-e",
+            f"MODEL_NAME={case}",
+            "-p",
+            f"{HOST_PORT}:8080",
+            image,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _wait_ready(case: str, container_id: str, timeout_s: int = 300):
+    deadline = time.time() + timeout_s
+    url = f"http://localhost:{HOST_PORT}/v1/models/{case}"
+    while time.time() < deadline:
+        try:
+            if requests.get(url, timeout=5).status_code == 200:
+                return
+        except requests.RequestException:
+            pass
+        alive = (
+            subprocess.run(
+                ["docker", "inspect", container_id],
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+        if not alive:
+            raise RuntimeError(f"container for '{case}' exited during startup")
+        time.sleep(3)
+    raise TimeoutError(f"server for '{case}' not ready within {timeout_s}s")
+
+
+def _mask_string(key: str) -> bool:
+    return key in ("class_mask", "valid_mask")
+
+
+def _png_mismatch(a_b64: str, b_b64: str) -> float:
+    a = np.asarray(Image.open(io.BytesIO(base64.b64decode(a_b64))))
+    b = np.asarray(Image.open(io.BytesIO(base64.b64decode(b_b64))))
+    if a.shape != b.shape:
+        return 1.0
+    return float(np.mean(a != b))
+
+
+def _bbox_dict_iou(a, b) -> float:
+    x1, y1 = max(a["x1"], b["x1"]), max(a["y1"], b["y1"])
+    x2, y2 = min(a["x2"], b["x2"]), min(a["y2"], b["y2"])
+    inter = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    area_a = (a["x2"] - a["x1"]) * (a["y2"] - a["y1"])
+    area_b = (b["x2"] - b["x1"]) * (b["y2"] - b["y1"])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _is_detection_list(value) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(v, dict) and "bbox" in v and "class" in v for v in value)
+    )
+
+
+def _align_detections(golden_list, got_list):
+    """Reorder got_list to match golden_list (greedy class + IoU >= 0.5).
+
+    Detection order is not part of the serving contract: near-tied scores
+    swap TopK order across onnxruntime versions. Unmatched leftovers are
+    appended so count mismatches still surface.
+    """
+    aligned = []
+    used = set()
+    for g in golden_list:
+        best, best_iou = None, 0.5
+        for j, a in enumerate(got_list):
+            if j in used or a.get("class") != g.get("class"):
+                continue
+            iou = _bbox_dict_iou(g["bbox"], a["bbox"])
+            if iou >= best_iou:
+                best, best_iou = j, iou
+        if best is not None:
+            used.add(best)
+            aligned.append(got_list[best])
+    aligned.extend(a for j, a in enumerate(got_list) if j not in used)
+    return aligned
+
+
+def _rec(records, path, golden, got, ok, detail=""):
+    records.append(
+        {"field": path, "golden": golden, "got": got, "ok": bool(ok), "detail": detail}
+    )
+
+
+def compare_response(got, golden, tol, path=""):
+    """Generic tolerant comparison of response JSON; structured records."""
+    records = []
+    if isinstance(golden, dict):
+        if not isinstance(got, dict):
+            _rec(records, path, "object", type(got).__name__, False)
+            return records
+        for key, expected in golden.items():
+            if key == "debug_image":
+                continue
+            if key not in got:
+                _rec(records, f"{path}.{key}", "present", "missing", False)
+                continue
+            if _mask_string(key) and isinstance(expected, str):
+                mismatch = _png_mismatch(got[key], expected)
+                _rec(
+                    records,
+                    f"{path}.{key}",
+                    "—",
+                    f"pixel mismatch {mismatch:.2e}",
+                    mismatch <= tol["pixel_mismatch_max"],
+                    f"(max {tol['pixel_mismatch_max']})",
+                )
+            else:
+                got_value = got[key]
+                if _is_detection_list(expected) and _is_detection_list(got_value):
+                    got_value = _align_detections(expected, got_value)
+                records.extend(
+                    compare_response(got_value, expected, tol, f"{path}.{key}")
+                )
+        for key in got:
+            if key != "debug_image" and key not in golden:
+                _rec(records, f"{path}.{key}", "absent", "present", False)
+    elif isinstance(golden, list):
+        if not isinstance(got, list) or len(got) != len(golden):
+            got_len = len(got) if isinstance(got, list) else "?"
+            _rec(records, f"{path} length", len(golden), got_len, False)
+            return records
+        for i, (a, g) in enumerate(zip(got, golden, strict=True)):
+            records.extend(compare_response(a, g, tol, f"{path}[{i}]"))
+    elif isinstance(golden, bool) or golden is None or isinstance(golden, str):
+        _rec(records, path, golden, got, got == golden)
+    elif isinstance(golden, (int, float)):
+        atol = (
+            tol["bbox_atol"]
+            if path.endswith(("x1", "y1", "x2", "y2"))
+            else tol["score_atol"]
+        )
+        delta = abs(float(got) - float(golden))
+        _rec(
+            records,
+            path,
+            round(float(golden), 5),
+            round(float(got), 5),
+            delta <= atol,
+            f"Δ{delta:.2e} (tol {atol})",
+        )
+    return records
+
+
+@pytest.mark.parametrize("case", _docker_cases())
+def test_docker_case_matches_golden(manifest, docker_image, case):
+    golden = harness.fetch_golden(manifest, f"{case}.docker")
+    if golden is None:
+        pytest.fail(f"no docker golden for '{case}'")
+    tolerances = harness.case_tolerances(manifest, manifest["cases"][case])
+
+    case_dir = harness.fetch_case_assets(manifest, case)
+    images_dir = os.path.join(case_dir, "images")
+    names = sorted(os.listdir(images_dir))
+
+    container_id = _start_container(docker_image, manifest, case)
+    try:
+        _wait_ready(case, container_id)
+        failures = []
+        for variant in harness.case_variants(manifest["cases"][case]):
+            golden_variant = golden["variants"].get(variant["name"])
+            if golden_variant is None:
+                failures.append(f"[{variant['name']}] missing from docker golden")
+                continue
+            for name in names:
+                # one image per request: fixed-batch-1 graphs + production shape
+                with open(os.path.join(images_dir, name), "rb") as f:
+                    instance = {"image": base64.b64encode(f.read()).decode()}
+                response = requests.post(
+                    f"http://localhost:{HOST_PORT}/v1/models/{case}:predict",
+                    json={
+                        "instances": [instance],
+                        "parameters": variant.get("predict_params", {}),
+                    },
+                    timeout=600,
+                )
+                response.raise_for_status()
+                prediction = response.json()["predictions"][0]
+                after_b64 = prediction.pop("debug_image", None)
+                records = compare_response(prediction, golden_variant[name], tolerances)
+                before = None
+                golden_annotated = harness.golden_annotated_dir(
+                    manifest, case, kind="docker-annotated"
+                )
+                if golden_annotated:
+                    path = os.path.join(
+                        golden_annotated, variant["name"], f"{name}.jpg"
+                    )
+                    if os.path.exists(path):
+                        with open(path, "rb") as f:
+                            before = f.read()
+                collect_image_block(
+                    f"{case} — serving (docker)",
+                    f"{name} / {variant['name']}",
+                    records,
+                    before=before,
+                    after=base64.b64decode(after_b64) if after_b64 else None,
+                    captions=("before (golden server)", "after (current server)"),
+                )
+                failures.extend(
+                    f"[{variant['name']}] {name}{r['field']}: "
+                    f"golden={r['golden']} got={r['got']} {r['detail']}"
+                    for r in records
+                    if not r["ok"]
+                )
+        assert not failures, "\n".join(failures)
+    finally:
+        subprocess.run(["docker", "stop", container_id], capture_output=True)

--- a/tests/equivalence/test_equivalence.py
+++ b/tests/equivalence/test_equivalence.py
@@ -1,0 +1,108 @@
+"""Predictor-level golden equivalence: get_predictor -> predict -> outputs.
+
+Each test also feeds the end-of-session HTML report (see conftest) with
+before/after annotated images and per-field diff records.
+"""
+
+import os
+
+import pytest
+
+from . import harness
+from .conftest import collect_image_block
+
+
+def _cases():
+    if not harness.manifest_location():
+        return []
+    manifest = harness.load_manifest()
+    return sorted(manifest["cases"].keys())
+
+
+def evaluate_case(manifest, case, annotate=True):
+    """Run one case on the current code.
+
+    Returns (got_by_variant, annotated_by_variant, golden).
+    """
+    case_cfg = manifest["cases"][case]
+    case_dir = harness.fetch_case_assets(manifest, case)
+    golden = harness.fetch_golden(manifest, case)
+
+    if "query_case" in case_cfg:  # vector index, chained from embeddings
+        query_dir = harness.fetch_case_assets(manifest, case_cfg["query_case"])
+        query_predictor = harness.load_case_predictor(query_dir)
+        query_outputs = harness.extract_outputs(
+            query_predictor,
+            harness.case_model_type(query_dir),
+            harness.load_case_images(query_dir),
+            {},
+        )
+        embeddings = {k: v["embedding"] for k, v in query_outputs.items()}
+        index = harness.load_case_predictor(case_dir)
+        got = harness.run_vector_index_case(index, embeddings, case_cfg.get("top_k", 5))
+        return {"default": got}, {"default": {}}, golden
+
+    predictor = harness.load_case_predictor(case_dir)
+    model_type = harness.case_model_type(case_dir)
+    images = harness.load_case_images(case_dir)
+    assert images, f"case '{case}' has no images"
+
+    got_by_variant = {}
+    annotated_by_variant = {}
+    for variant in harness.case_variants(case_cfg):
+        outputs, annotated = harness.evaluate_variant(
+            predictor,
+            model_type,
+            images,
+            variant.get("predict_params", {}),
+            annotate=annotate,
+        )
+        got_by_variant[variant["name"]] = outputs
+        annotated_by_variant[variant["name"]] = annotated
+    return got_by_variant, annotated_by_variant, golden
+
+
+def _golden_annotated(manifest, case, variant_name, image_name, kind="annotated"):
+    directory = harness.golden_annotated_dir(manifest, case, kind=kind)
+    if directory is None:
+        return None
+    path = os.path.join(directory, variant_name, f"{image_name}.jpg")
+    if not os.path.exists(path):
+        return None
+    with open(path, "rb") as f:
+        return f.read()
+
+
+@pytest.mark.parametrize("case", _cases())
+def test_case_matches_golden(manifest, case):
+    got_by_variant, annotated_by_variant, golden = evaluate_case(manifest, case)
+    if golden is None:
+        pytest.fail(
+            f"no golden for case '{case}' — generate with generate_goldens.py, "
+            "review, and upload manually"
+        )
+    tolerances = harness.case_tolerances(manifest, manifest["cases"][case])
+
+    all_failures = []
+    for variant_name, got in sorted(got_by_variant.items()):
+        golden_variant = golden["variants"].get(variant_name)
+        if golden_variant is None:
+            all_failures.append(f"[{variant_name}] missing from golden file")
+            continue
+        for image_name in sorted(golden_variant):
+            records = harness.compare_outputs(
+                {image_name: got.get(image_name, {})},
+                {image_name: golden_variant[image_name]},
+                tolerances,
+            )
+            collect_image_block(
+                case,
+                f"{image_name} / {variant_name}",
+                records,
+                before=_golden_annotated(manifest, case, variant_name, image_name),
+                after=annotated_by_variant[variant_name].get(image_name),
+            )
+            all_failures.extend(
+                f"[{variant_name}] {failure}" for failure in harness.failures(records)
+            )
+    assert not all_failures, "\n".join(all_failures)


### PR DESCRIPTION
## Summary

Adds a test suite that runs real models on real photos and compares the outputs against reviewed golden files, so any change that shifts model outputs is caught before merge. It covers two layers per model type: predictor-level (`get_predictor` → `predict` → extracted outputs, run in-process) and serving-level (boots the actual Docker serving image per case and checks the HTTP responses).

The repository contains only a generic harness. Models, photos, goldens, and the manifest that defines the cases, predict-parameter variants, and tolerances all live in a private GCS prefix reached through the `ORIENT_EXPRESS_TEST_MANIFEST` environment variable. Without that variable every test skips, so public CI and external contributors never see this suite run and the repo carries no internal names.

Every run automatically writes an HTML report (default `test-output/equivalence_report.html`) showing, for each case, variant, and image, the golden code's annotated image next to the current code's, followed by a per-field diff table that includes within-tolerance deltas — so drift is visible before it becomes a failure. A test fails exactly when its image shows DIFFERS in the report.

Comparison is tolerance-based rather than bit-exact, because BLAS, onnxruntime, and image-decoding versions introduce real float-level wiggle across environments (measured and documented in the manifest). Class and argmax equality are always strict, and detection lists are matched order-independently by class and IoU, since near-tied scores legitimately swap top-k order across onnxruntime versions. Prediction always runs one image per `predict` call, matching production traffic and supporting models exported with a fixed batch dimension of 1.

Goldens are never regenerated automatically: `generate_goldens.py` writes candidates locally (including the generating code's annotated images), they are reviewed via `ORIENT_EXPRESS_TEST_GOLDENS_DIR` plus the report, and uploading them to the prefix is a deliberate manual act documented as irreversible. Each golden records the library version, commit, and platform that produced it.

Current goldens were generated from the pre-refactor release (v2.4.2 library code and the production v2.4.2 serving image)