### PR TITLE
Add predictor registry and typed loading

### DIFF
--- a/orient_express/predictors/__init__.py
+++ b/orient_express/predictors/__init__.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from typing import Any, TypeVar, overload

--- a/orient_express/predictors/__init__.py
+++ b/orient_express/predictors/__init__.py
@@ -1,9 +1,8 @@
-import json
 import logging
 import os
+from typing import Any, TypeVar, overload
 
 import joblib
-import numpy as np
 import yaml
 
 from ..utils.paths import get_metadata_path
@@ -18,26 +17,41 @@ from .multi_label_classification import (
     MultiLabelClassificationPredictor,
 )
 from .object_detection import BoundingBoxPrediction, BoundingBoxPredictor
-from .predictor import ImagePredictor, Predictor
+from .predictor import PREDICTOR_REGISTRY, ImagePredictor, Predictor
 from .semantic_segmentation import (
     SemanticSegmentationPrediction,
     SemanticSegmentationPredictor,
 )
 from .vector_index import CropSpec, SearchResult, VectorIndex, build_vector_index
 
+T = TypeVar("T")
 
-def get_predictor(dir: str, device: str = "cpu"):
-    downloaded_files = os.listdir(dir)
+
+@overload
+def get_predictor(dir: str, device: str = "cpu") -> Any: ...
+
+
+@overload
+def get_predictor(dir: str, device: str = "cpu", *, expected_type: type[T]) -> T: ...
+
+
+def get_predictor(
+    dir: str, device: str = "cpu", *, expected_type: type[T] | None = None
+) -> Any:
+    """Load whatever model artifact lives in `dir`.
+
+    The concrete class is chosen at runtime by the model_type recorded in
+    metadata.yaml, so the static return type is unknown. Pass expected_type
+    to narrow the type for the checker and assert it at runtime:
+
+        predictor = get_predictor(dir, expected_type=BoundingBoxPredictor)
+    """
     metadata_path = get_metadata_path(dir)
     if not os.path.exists(metadata_path):
         logging.warning(
             f"No metadata.yaml file found in {dir}. Will try to load model from joblib file."
         )
-        for file in downloaded_files:
-            if file.endswith(".joblib"):
-                file_path = os.path.join(dir, file)
-                return joblib.load(file_path)
-        raise Exception(f"No joblib file found in {dir}")
+        predictor = _load_joblib_fallback(dir)
     else:
         with open(metadata_path) as f:
             metadata = yaml.safe_load(f)
@@ -47,58 +61,30 @@ def get_predictor(dir: str, device: str = "cpu"):
         if "model_file" not in metadata:
             raise Exception("No model_file defined in metadata.yaml")
         if model_type == "joblib":
-            joblib_path = os.path.join(dir, metadata["model_file"])
-            return joblib.load(joblib_path)
-        elif model_type == InstanceSegmentationPredictor.model_type:
-            return load_image_predictor(
-                InstanceSegmentationPredictor, dir, metadata, device
-            )
-        elif model_type == BoundingBoxPredictor.model_type:
-            return load_image_predictor(BoundingBoxPredictor, dir, metadata, device)
-        elif model_type == SemanticSegmentationPredictor.model_type:
-            return load_image_predictor(
-                SemanticSegmentationPredictor, dir, metadata, device
-            )
-        elif model_type == ClassificationPredictor.model_type:
-            return load_image_predictor(ClassificationPredictor, dir, metadata, device)
-        elif model_type == MultiLabelClassificationPredictor.model_type:
-            return load_image_predictor(
-                MultiLabelClassificationPredictor, dir, metadata, device
-            )
-        elif model_type == FeatureExtractionPredictor.model_type:
-            return load_feature_extractor(dir, metadata, device)
-        elif model_type == VectorIndex.model_type:
-            return load_vector_index(dir, metadata)
+            predictor = joblib.load(os.path.join(dir, metadata["model_file"]))
         else:
-            raise Exception(f"Unknown model_type '{model_type}'")
+            predictor_class = PREDICTOR_REGISTRY.get(model_type)
+            if predictor_class is None:
+                raise Exception(f"Unknown model_type '{model_type}'")
+            predictor = predictor_class.from_dir(dir, metadata, device)
+    if expected_type is not None and not isinstance(predictor, expected_type):
+        raise TypeError(
+            f"Expected {expected_type.__name__} but artifact in {dir} loaded as "
+            f"{type(predictor).__name__}"
+        )
+    return predictor
 
 
-def load_image_predictor(
-    model_type: type[ImagePredictor], dir: str, metadata: dict, device: str = "cpu"
-):
-    onnx_path = os.path.join(dir, metadata["model_file"])
-    if "classes" not in metadata:
-        raise Exception("No classes defined in metadata.yaml")
-    classes = metadata["classes"]
-    return model_type(onnx_path, classes, device)
+def _load_joblib_fallback(dir: str):
+    for file in os.listdir(dir):
+        if file.endswith(".joblib"):
+            return joblib.load(os.path.join(dir, file))
+    raise Exception(f"No joblib file found in {dir}")
 
 
-def load_feature_extractor(dir: str, metadata: dict, device: str = "cpu"):
-    onnx_path = os.path.join(dir, metadata["model_file"])
-    return FeatureExtractionPredictor(onnx_path, device)
-
-
-def load_vector_index(dir: str, metadata: dict | None = None):
+def load_vector_index(dir: str, metadata: dict | None = None) -> VectorIndex:
     if metadata is None:
-        metadata_path = get_metadata_path(dir)
-        with open(metadata_path) as f:
+        with open(get_metadata_path(dir)) as f:
             metadata = yaml.safe_load(f)
     assert metadata is not None
-    artifact_path = os.path.join(dir, metadata["model_file"])
-    data = np.load(artifact_path, allow_pickle=False)
-    vectors = data["vectors"]
-    labels = json.loads(str(data["labels_json"]))
-    labels = [tuple(label) if isinstance(label, list) else label for label in labels]
-    index = VectorIndex(vectors=vectors, labels=labels)
-    index.model_path = artifact_path
-    return index
+    return VectorIndex.from_dir(dir, metadata)

--- a/orient_express/predictors/feature_extraction.py
+++ b/orient_express/predictors/feature_extraction.py
@@ -35,6 +35,13 @@ class FeatureExtractionPredictor(ImagePredictor):
         self.model = self.backend_model(model_path, device)
         self.model_path = model_path
 
+    @classmethod
+    def from_dir(cls, dir: str, metadata: dict, device: str = "cpu"):
+        if "model_file" not in metadata:
+            raise Exception("No model_file defined in metadata.yaml")
+        onnx_path = os.path.join(dir, metadata["model_file"])
+        return cls(onnx_path, device)
+
     def predict(self, images: list[Image.Image]) -> list[FeaturePrediction]:
         if not images:
             return []

--- a/orient_express/predictors/predictor.py
+++ b/orient_express/predictors/predictor.py
@@ -32,9 +32,32 @@ def get_image_onnx_container_uri() -> str:
     return f"{IMAGE_ONNX_IMAGE_REPO}:{tag}"
 
 
+# model_type string (persisted in every uploaded metadata.yaml) -> class.
+# Populated automatically when a Predictor subclass defines `model_type`.
+PREDICTOR_REGISTRY: dict[str, type["Predictor"]] = {}
+
+
 class Predictor(ABC):
     model_type: str
     model_path: str
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        model_type = cls.__dict__.get("model_type")
+        if isinstance(model_type, str):
+            existing = PREDICTOR_REGISTRY.get(model_type)
+            if existing is not None and existing is not cls:
+                raise ValueError(
+                    f"model_type '{model_type}' is already registered by "
+                    f"{existing.__name__}; model_type strings must be unique "
+                    "(they are persisted in uploaded model metadata)"
+                )
+            PREDICTOR_REGISTRY[model_type] = cls
+
+    @classmethod
+    def from_dir(cls, dir: str, metadata: dict, device: str = "cpu") -> "Predictor":
+        """Construct this predictor from a downloaded artifact directory."""
+        raise NotImplementedError(f"{cls.__name__} does not implement from_dir")
 
     @abstractmethod
     def get_serving_container_image_uri(self) -> str:
@@ -63,6 +86,15 @@ class ImagePredictor(Predictor):
         self.color_scheme = generate_color_scheme(list(classes.values()))
         self.classes = classes
         self.model_path = model_path
+
+    @classmethod
+    def from_dir(cls, dir: str, metadata: dict, device: str = "cpu"):
+        if "model_file" not in metadata:
+            raise Exception("No model_file defined in metadata.yaml")
+        if "classes" not in metadata:
+            raise Exception("No classes defined in metadata.yaml")
+        onnx_path = os.path.join(dir, metadata["model_file"])
+        return cls(onnx_path, metadata["classes"], device)
 
     def get_serving_container_image_uri(self):
         return get_image_onnx_container_uri()

--- a/orient_express/predictors/vector_index.py
+++ b/orient_express/predictors/vector_index.py
@@ -147,6 +147,19 @@ class VectorIndex(Predictor):
 
         return VectorIndex(vectors=centroids, labels=new_labels)
 
+    @classmethod
+    def from_dir(cls, dir: str, metadata: dict, device: str = "cpu") -> "VectorIndex":
+        artifact_path = os.path.join(dir, metadata["model_file"])
+        data = np.load(artifact_path, allow_pickle=False)
+        vectors = data["vectors"]
+        labels = json.loads(str(data["labels_json"]))
+        labels = [
+            tuple(label) if isinstance(label, list) else label for label in labels
+        ]
+        index = cls(vectors=vectors, labels=labels)
+        index.model_path = artifact_path
+        return index
+
     def get_serving_container_image_uri(self) -> str:
         warnings.warn(
             "VectorIndex does not support serving via a container. Returning incompatible image URI.",

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, TypeVar, overload
 
 import joblib
 import yaml
@@ -10,6 +11,8 @@ from google.cloud.storage import transfer_manager
 
 from .predictors import Predictor, get_predictor
 from .utils.paths import get_cache_dir
+
+T = TypeVar("T")
 
 ARTIFACT_DIR = get_cache_dir()
 _last_vertex_init: tuple[str, str] | None = None
@@ -85,10 +88,41 @@ class VertexModel:
         predictions = self.endpoint.predict(instances=instances, parameters=parameters)
         return predictions.predictions
 
-    def get_local_predictor(self, device: str = "cpu", force_download: bool = False):
+    @overload
+    def get_local_predictor(
+        self, device: str = "cpu", force_download: bool = False
+    ) -> Any: ...
+
+    @overload
+    def get_local_predictor(
+        self,
+        device: str = "cpu",
+        force_download: bool = False,
+        *,
+        expected_type: type[T],
+    ) -> T: ...
+
+    def get_local_predictor(
+        self,
+        device: str = "cpu",
+        force_download: bool = False,
+        *,
+        expected_type: type[T] | None = None,
+    ) -> Any:
+        """Download this model's artifacts (cached) and load a local predictor.
+
+        Pass expected_type to narrow the static return type and get a runtime
+        check that the artifact really is that predictor class:
+
+            predictor = vertex_model.get_local_predictor(
+                expected_type=BoundingBoxPredictor
+            )
+        """
         dir = os.path.join(ARTIFACT_DIR, self.model_name + "-" + str(self.version))
         self.download_artifacts(dir, force_download=force_download)
-        return get_predictor(dir, device)
+        if expected_type is None:
+            return get_predictor(dir, device)
+        return get_predictor(dir, device, expected_type=expected_type)
 
     def download_artifacts(self, dir: str, force_download: bool = True):
         download_artifacts(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,76 @@
+"""Tests for the predictor registry and typed loading."""
+
+import os
+
+import pytest
+import yaml
+
+from orient_express.predictors import (
+    PREDICTOR_REGISTRY,
+    BoundingBoxPredictor,
+    ClassificationPredictor,
+    FeatureExtractionPredictor,
+    InstanceSegmentationPredictor,
+    MultiLabelClassificationPredictor,
+    SemanticSegmentationPredictor,
+    VectorIndex,
+    get_predictor,
+)
+from orient_express.predictors.predictor import Predictor
+
+
+class TestRegistry:
+    def test_all_model_types_registered(self):
+        """The frozen model_type strings (persisted in GCS metadata) resolve."""
+        expected = {
+            "classification-onnx": ClassificationPredictor,
+            "multi-label-classification-onnx": MultiLabelClassificationPredictor,
+            "object-detection-onnx": BoundingBoxPredictor,
+            "instance-segmentation-onnx": InstanceSegmentationPredictor,
+            "semantic-segmentation-onnx": SemanticSegmentationPredictor,
+            "feature-extraction-onnx": FeatureExtractionPredictor,
+            "vector-index": VectorIndex,
+        }
+        for model_type, predictor_class in expected.items():
+            assert PREDICTOR_REGISTRY[model_type] is predictor_class
+
+    def test_duplicate_model_type_rejected(self):
+        with pytest.raises(ValueError, match="already registered"):
+
+            class Duplicate(Predictor):  # noqa: F841
+                model_type = "vector-index"
+
+    def test_subclass_without_model_type_not_registered(self):
+        before = dict(PREDICTOR_REGISTRY)
+
+        class Intermediate(Predictor):
+            pass
+
+        assert PREDICTOR_REGISTRY == before
+
+
+class TestExpectedType:
+    def test_mismatched_expected_type_raises(self, tmp_path):
+        import numpy as np
+
+        index = VectorIndex(vectors=np.ones((2, 4)), labels=["a", "b"])
+        index.dump(str(tmp_path))
+
+        with pytest.raises(TypeError, match="Expected BoundingBoxPredictor"):
+            get_predictor(str(tmp_path), expected_type=BoundingBoxPredictor)
+
+    def test_matching_expected_type_returns_predictor(self, tmp_path):
+        import numpy as np
+
+        index = VectorIndex(vectors=np.ones((2, 4)), labels=["a", "b"])
+        index.dump(str(tmp_path))
+
+        loaded = get_predictor(str(tmp_path), expected_type=VectorIndex)
+        assert isinstance(loaded, VectorIndex)
+        assert len(loaded) == 2
+
+    def test_unknown_model_type_raises(self, tmp_path):
+        with open(os.path.join(tmp_path, "metadata.yaml"), "w") as f:
+            yaml.dump({"model_type": "not-a-thing", "model_file": "x.bin"}, f)
+        with pytest.raises(Exception, match="Unknown model_type"):
+            get_predictor(str(tmp_path))


### PR DESCRIPTION
## Summary

Predictor subclasses that define a `model_type` now self-register via `__init_subclass__` into `PREDICTOR_REGISTRY`, and duplicate `model_type` strings are rejected at class-definition time — those strings are persisted in every uploaded `metadata.yaml`, so uniqueness is a hard invariant and the existing strings are frozen.

`get_predictor` dispatches through the registry and each class's `from_dir(dir, metadata, device)` classmethod. The previous if/elif chain and the `load_image_predictor` / `load_feature_extractor` helpers are gone, and new predictor types load through `get_predictor` with no changes to it.

Loading is now typed: `get_predictor` and `VertexModel.get_local_predictor` accept `expected_type=SomePredictor`, which narrows the static return type through overloads (editors and type checkers know exactly what came back) and raises `TypeError` at runtime if the artifact loads as a different class. Omitting it keeps today's behavior exactly.

```python
predictor = vertex_model.get_local_predictor(expected_type=BoundingBoxPredictor)
predictor.predict(...)  # fully typed
```

`load_vector_index` remains available as a thin wrapper over `VectorIndex.from_dir`.