### PR TITLE
Make inference servers model-agnostic

### DIFF
--- a/docker-image-onnx/run_inference_server.py
+++ b/docker-image-onnx/run_inference_server.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import logging.config
 import os
@@ -6,18 +5,9 @@ from concurrent.futures import ThreadPoolExecutor
 
 from kserve import Model, ModelServer
 
-from orient_express.predictors import (
-    ClassificationPredictor,
-    get_predictor,
-)
-from orient_express.utils.image_processor import (
-    base64_to_image,
-    fix_rotation,
-    image_to_base64,
-    read_image_from_gs,
-    read_image_from_url,
-)
-from orient_express.utils.retry import retry
+from orient_express.predictors import get_predictor
+from orient_express.serving import build_predict_kwargs, decode_input, download_image
+from orient_express.utils.image_processor import fix_rotation
 from orient_express.vertex import ARTIFACT_DIR, download_artifacts
 
 
@@ -43,12 +33,15 @@ class OnnxImageModel(Model):
         assert self.model is not None
 
         try:
-            decoded_input = self.decode_input(inputs)
+            decoded_input = decode_input(inputs)
             instances = decoded_input["instances"]
-            parameters = decoded_input.get("parameters", {})
+            parameters = decoded_input.get("parameters", {}) or {}
         except Exception as e:
             logging.exception(f"[{self.name}] failed to decode input: {e}\n{inputs}")
             return {"error": "Failed to decode input"}
+
+        include_debug = bool(parameters.get("debug_image", True))
+        predict_kwargs = build_predict_kwargs(self.model.predict, parameters)
 
         predictions: list[dict] = [{} for _ in instances]
 
@@ -56,7 +49,7 @@ class OnnxImageModel(Model):
         image_idxs = []
         with ThreadPoolExecutor() as executor:
             futures = [
-                executor.submit(self.download_image, instance["image"])
+                executor.submit(download_image, instance["image"])
                 for instance in instances
             ]
 
@@ -72,88 +65,27 @@ class OnnxImageModel(Model):
                     )
                     predictions[img_idx] = {"status": "failed to download image"}
 
-        if isinstance(self.model, ClassificationPredictor):
-            model_predictions = self.model.predict(images)
+        model_predictions = self.model.predict(images, **predict_kwargs)
 
-            for pred_idx, prediction in enumerate(model_predictions):
+        with ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(
+                    self.model.to_response, image, prediction, include_debug
+                )
+                for image, prediction in zip(images, model_predictions, strict=True)
+            ]
+
+            for pred_idx, future in enumerate(futures):
                 img_idx = image_idxs[pred_idx]
-                predictions[img_idx] = prediction.to_dict()
-                predictions[img_idx]["status"] = "success"
-
-        else:
-            confidence = parameters.get("confidence", 0.5)
-            model_predictions = self.model.predict(images, confidence)
-
-            with ThreadPoolExecutor() as executor:
-                futures = [
-                    executor.submit(self.get_debug_image, image, prediction)
-                    for image, prediction in zip(images, model_predictions, strict=True)
-                ]
-
-                for pred_idx, future in enumerate(futures):
-                    img_idx = image_idxs[pred_idx]
-                    try:
-                        debug_b64 = future.result()
-                        prediction = model_predictions[pred_idx]
-                        if isinstance(prediction, list):
-                            predictions_json = [pred.to_dict() for pred in prediction]
-                        else:
-                            predictions_json = prediction.to_dict()
-
-                        predictions[img_idx] = {
-                            "status": "success",
-                            "predictions": predictions_json,
-                            "debug_image": debug_b64,
-                        }
-                    except Exception as e:
-                        logging.exception(
-                            f"[{self.name}] failed to get debug image {img_idx}: {e}"
-                        )
-                        predictions[img_idx] = {"status": "failed to get debug image"}
+                try:
+                    predictions[img_idx] = future.result()
+                except Exception as e:
+                    logging.exception(
+                        f"[{self.name}] failed to build response {img_idx}: {e}"
+                    )
+                    predictions[img_idx] = {"status": "failed to get debug image"}
 
         return {"predictions": predictions}
-
-    def decode_input(self, input_data):
-        logging.info(f"PayloadType: {type(input_data)}")
-        if isinstance(input_data, (bytes, str)):
-            return json.loads(input_data)
-        elif isinstance(input_data, dict):
-            return input_data
-        else:
-            raise Exception(f"unsupported payload type {type(input_data)}")
-
-    @retry(retries=3)
-    def download_image(self, image_address):
-        if image_address.startswith("http"):
-            # http url
-            logging.info(f"[{self.name}] image source: http url {image_address}")
-            image = read_image_from_url(image_address)
-        elif image_address.startswith("gs://"):
-            # gs uri
-            logging.info(f"[{self.name}] image source: gcs uri {image_address}")
-            image = read_image_from_gs(image_address)
-        elif image_address.startswith("data:"):
-            # data URI format: data:image/png;base64,iVBORw0KGgo...
-            base64_data = image_address.split(",", 1)[1]
-            logging.info(
-                f"[{self.name}] image source: base64 data uri ({len(base64_data)} base64 chars)"
-            )
-            image = base64_to_image(base64_data)
-        else:
-            # raw base64
-            logging.info(
-                f"[{self.name}] image source: raw base64 ({len(image_address)} base64 chars)"
-            )
-            image = base64_to_image(image_address)
-        return image
-
-    def get_debug_image(self, image, preds):
-        assert self.model is not None
-        debug_image = self.model.get_annotated_image(image, preds)
-        if debug_image is None:  # classification model
-            return None
-        debug_image_b64 = image_to_base64(debug_image)
-        return debug_image_b64
 
 
 if __name__ == "__main__":

--- a/docker-xgboost-scikit-learn/run_inference_server.py
+++ b/docker-xgboost-scikit-learn/run_inference_server.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import logging.config
 import os
@@ -7,6 +6,7 @@ import pandas as pd
 from kserve import Model, ModelServer
 
 from orient_express.predictors import get_predictor
+from orient_express.serving import decode_input
 from orient_express.vertex import ARTIFACT_DIR, download_artifacts
 
 
@@ -28,22 +28,13 @@ class ScikitLearnPipelineModel(Model):
 
     def predict(self, inputs, *args, **kwargs):
         logging.info(f"[{self.name}] executing prediction")
-        decoded_input = self.decode_input(inputs)
+        decoded_input = decode_input(inputs)
 
         input_df = pd.DataFrame(decoded_input["instances"])
 
         predictions = self.model.predict(input_df)
         response = {"predictions": predictions.tolist()}
         return response
-
-    def decode_input(self, input_data):
-        logging.info(f"PayloadType: {type(input_data)}")
-        if isinstance(input_data, (bytes, str)):
-            return json.loads(input_data)
-        elif isinstance(input_data, dict):
-            return input_data
-        else:
-            raise Exception(f"Unsupported payload type {type(input_data)}")
 
 
 if __name__ == "__main__":

--- a/orient_express/predictors/__init__.py
+++ b/orient_express/predictors/__init__.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 from typing import Any, TypeVar, overload

--- a/orient_express/predictors/__init__.py
+++ b/orient_express/predictors/__init__.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from typing import Any, TypeVar, overload

--- a/orient_express/predictors/classification.py
+++ b/orient_express/predictors/classification.py
@@ -57,3 +57,8 @@ class ClassificationPredictor(ImagePredictor):
         self, image: Image.Image, predictions: ClassificationPrediction
     ):
         return None
+
+    def to_response(self, image, prediction, include_debug: bool = True):
+        # Historical (pre-to_response) response shape for classification:
+        # flat prediction fields with a status key, no debug image.
+        return {**prediction.to_dict(), "status": "success"}

--- a/orient_express/predictors/predictor.py
+++ b/orient_express/predictors/predictor.py
@@ -11,7 +11,7 @@ import yaml
 from PIL import Image
 
 from ..utils.colors import generate_color_scheme
-from ..utils.image_processor import image_to_array
+from ..utils.image_processor import image_to_array, image_to_base64
 from ..utils.paths import get_metadata_path
 
 IMAGE_ONNX_IMAGE_REPO = (
@@ -104,6 +104,25 @@ class ImagePredictor(Predictor):
 
     def get_serving_container_predict_route(self, model_name):
         return f"/v1/models/{model_name}:predict"
+
+    def to_response(self, image: Image.Image, prediction, include_debug: bool = True):
+        """Per-image response dict served by the inference container.
+
+        The shape is part of the serving API — existing clients parse the
+        `status`/`predictions`/`debug_image` keys.
+        """
+        if isinstance(prediction, list):
+            predictions_json = [single.to_dict() for single in prediction]
+        else:
+            predictions_json = prediction.to_dict()
+        response = {"status": "success", "predictions": predictions_json}
+        if include_debug:
+            debug_image = self.get_annotated_image(image, prediction)
+            if debug_image is None:
+                response["debug_image"] = None
+            else:
+                response["debug_image"] = image_to_base64(debug_image)
+        return response
 
     def dump(self, dir: str):
         metadata = {

--- a/orient_express/serving.py
+++ b/orient_express/serving.py
@@ -75,8 +75,6 @@ def build_predict_kwargs(predict_fn, parameters: dict) -> dict:
             continue
         if name in parameters:
             kwargs[name] = parameters[name]
-        elif (
-            param.default is inspect.Parameter.empty and name in SERVER_PARAM_DEFAULTS
-        ):
+        elif param.default is inspect.Parameter.empty and name in SERVER_PARAM_DEFAULTS:
             kwargs[name] = SERVER_PARAM_DEFAULTS[name]
     return kwargs

--- a/orient_express/serving.py
+++ b/orient_express/serving.py
@@ -1,0 +1,82 @@
+"""Helpers shared by the kserve inference servers in docker-image-onnx/ and
+docker-xgboost-scikit-learn/.
+
+kserve itself is deliberately not imported here — it is a `server`
+dependency-group package that only exists inside the Docker images.
+"""
+
+import inspect
+import json
+import logging
+
+from .utils.image_processor import (
+    base64_to_image,
+    read_image_from_gs,
+    read_image_from_url,
+)
+from .utils.retry import retry
+
+# Defaults the server supplies when a predictor's predict() requires a
+# parameter the request didn't provide.
+SERVER_PARAM_DEFAULTS = {"confidence": 0.5}
+
+# Request parameters that steer the server itself and must not be forwarded
+# to predict().
+RESERVED_PARAMETERS = {"debug_image"}
+
+
+def decode_input(input_data):
+    logging.info(f"PayloadType: {type(input_data)}")
+    if isinstance(input_data, (bytes, str)):
+        return json.loads(input_data)
+    elif isinstance(input_data, dict):
+        return input_data
+    else:
+        raise Exception(f"unsupported payload type {type(input_data)}")
+
+
+@retry(retries=3)
+def download_image(image_address):
+    if image_address.startswith("http"):
+        logging.info(f"image source: http url {image_address}")
+        return read_image_from_url(image_address)
+    elif image_address.startswith("gs://"):
+        logging.info(f"image source: gcs uri {image_address}")
+        return read_image_from_gs(image_address)
+    elif image_address.startswith("data:"):
+        # data URI format: data:image/png;base64,iVBORw0KGgo...
+        base64_data = image_address.split(",", 1)[1]
+        logging.info(f"image source: base64 data uri ({len(base64_data)} base64 chars)")
+        return base64_to_image(base64_data)
+    else:
+        logging.info(f"image source: raw base64 ({len(image_address)} base64 chars)")
+        return base64_to_image(image_address)
+
+
+def build_predict_kwargs(predict_fn, parameters: dict) -> dict:
+    """Map request `parameters` onto the predictor's own predict() signature.
+
+    Any parameter the signature declares is forwarded when present in the
+    request; required parameters missing from the request fall back to
+    SERVER_PARAM_DEFAULTS. Unknown request keys and RESERVED_PARAMETERS are
+    ignored, so the server needs no per-model-type dispatch.
+    """
+    signature = inspect.signature(predict_fn)
+    kwargs = {}
+    for name, param in signature.parameters.items():
+        if name in ("self", "images"):
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        if name in RESERVED_PARAMETERS:
+            continue
+        if name in parameters:
+            kwargs[name] = parameters[name]
+        elif (
+            param.default is inspect.Parameter.empty and name in SERVER_PARAM_DEFAULTS
+        ):
+            kwargs[name] = SERVER_PARAM_DEFAULTS[name]
+    return kwargs

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -1,0 +1,156 @@
+"""Tests for orient_express.serving helpers and predictor to_response shapes."""
+
+import json
+
+import pytest
+
+from orient_express.serving import build_predict_kwargs, decode_input
+
+
+class TestDecodeInput:
+    def test_decodes_json_string(self):
+        assert decode_input('{"instances": []}') == {"instances": []}
+
+    def test_decodes_json_bytes(self):
+        assert decode_input(b'{"instances": []}') == {"instances": []}
+
+    def test_passes_dict_through(self):
+        payload = {"instances": [1]}
+        assert decode_input(payload) is payload
+
+    def test_rejects_other_types(self):
+        with pytest.raises(Exception, match="unsupported payload type"):
+            decode_input(42)
+
+
+class TestBuildPredictKwargs:
+    def test_required_confidence_gets_server_default(self):
+        def predict(images, confidence):
+            pass
+
+        assert build_predict_kwargs(predict, {}) == {"confidence": 0.5}
+
+    def test_request_parameter_overrides_default(self):
+        def predict(images, confidence):
+            pass
+
+        assert build_predict_kwargs(predict, {"confidence": 0.9}) == {
+            "confidence": 0.9
+        }
+
+    def test_optional_parameter_forwarded_when_present(self):
+        def predict(images, confidence, nms_threshold=None):
+            pass
+
+        kwargs = build_predict_kwargs(
+            predict, {"confidence": 0.4, "nms_threshold": 0.3}
+        )
+        assert kwargs == {"confidence": 0.4, "nms_threshold": 0.3}
+
+    def test_optional_parameter_omitted_when_absent(self):
+        def predict(images, confidence, nms_threshold=None):
+            pass
+
+        assert build_predict_kwargs(predict, {}) == {"confidence": 0.5}
+
+    def test_no_parameters_for_bare_predict(self):
+        def predict(images):
+            pass
+
+        assert build_predict_kwargs(predict, {"confidence": 0.9}) == {}
+
+    def test_reserved_and_unknown_keys_ignored(self):
+        def predict(images, confidence):
+            pass
+
+        kwargs = build_predict_kwargs(
+            predict, {"confidence": 0.7, "debug_image": False, "bogus": 1}
+        )
+        assert kwargs == {"confidence": 0.7}
+
+    def test_defaulted_confidence_still_filled_from_request(self):
+        def predict(images, confidence=0.5):
+            pass
+
+        assert build_predict_kwargs(predict, {"confidence": 0.8}) == {
+            "confidence": 0.8
+        }
+
+
+class TestToResponse:
+    def _fake_detector(self):
+        """A BoundingBoxPredictor with the ONNX session swapped for a stub."""
+        from unittest.mock import MagicMock, patch
+
+        import numpy as np
+
+        from orient_express.predictors import BoundingBoxPredictor
+
+        session = MagicMock()
+        session.get_inputs.return_value = [
+            MagicMock(name="images", shape=[1, 640, 640, 3])
+        ]
+        session.get_outputs.return_value = []
+        with patch(
+            "orient_express.predictors.predictor.ort.InferenceSession",
+            return_value=session,
+        ):
+            predictor = BoundingBoxPredictor("fake.onnx", {1: "cat"})
+        return predictor, np.array([[0, 0, 10, 10, 0.9, 1]])
+
+    def test_detection_response_shape_with_debug(self):
+        from PIL import Image
+
+        predictor, boxes = self._fake_detector()
+        image = Image.new("RGB", (32, 32))
+        prediction = predictor.format_output(boxes)
+
+        response = predictor.to_response(image, prediction, include_debug=True)
+        assert response["status"] == "success"
+        assert isinstance(response["predictions"], list)
+        assert response["predictions"][0]["class"] == "cat"
+        assert isinstance(response["debug_image"], str)
+        json.dumps(response)  # response must be JSON-serializable
+
+    def test_detection_response_skips_debug_when_disabled(self):
+        from PIL import Image
+
+        predictor, boxes = self._fake_detector()
+        image = Image.new("RGB", (32, 32))
+        prediction = predictor.format_output(boxes)
+
+        response = predictor.to_response(image, prediction, include_debug=False)
+        assert "debug_image" not in response
+        assert response["status"] == "success"
+
+    def test_classification_response_is_flat(self):
+        from unittest.mock import MagicMock, patch
+
+        from PIL import Image
+
+        from orient_express.predictors import (
+            ClassificationPrediction,
+            ClassificationPredictor,
+        )
+
+        session = MagicMock()
+        session.get_inputs.return_value = [
+            MagicMock(name="images", shape=[1, 224, 224, 3])
+        ]
+        session.get_outputs.return_value = []
+        with patch(
+            "orient_express.predictors.predictor.ort.InferenceSession",
+            return_value=session,
+        ):
+            predictor = ClassificationPredictor("fake.onnx", {1: "cat"})
+
+        prediction = ClassificationPrediction(
+            clss="cat", score=0.9, class_scores={"cat": 0.9}
+        )
+        response = predictor.to_response(Image.new("RGB", (8, 8)), prediction)
+        assert response == {
+            "class": "cat",
+            "score": 0.9,
+            "class_scores": {"cat": 0.9},
+            "status": "success",
+        }

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -34,9 +34,7 @@ class TestBuildPredictKwargs:
         def predict(images, confidence):
             pass
 
-        assert build_predict_kwargs(predict, {"confidence": 0.9}) == {
-            "confidence": 0.9
-        }
+        assert build_predict_kwargs(predict, {"confidence": 0.9}) == {"confidence": 0.9}
 
     def test_optional_parameter_forwarded_when_present(self):
         def predict(images, confidence, nms_threshold=None):
@@ -72,9 +70,7 @@ class TestBuildPredictKwargs:
         def predict(images, confidence=0.5):
             pass
 
-        assert build_predict_kwargs(predict, {"confidence": 0.8}) == {
-            "confidence": 0.8
-        }
+        assert build_predict_kwargs(predict, {"confidence": 0.8}) == {"confidence": 0.8}
 
 
 class TestToResponse:


### PR DESCRIPTION
## Summary

Adds `orient_express/serving.py` with `decode_input`, `download_image`, and `build_predict_kwargs`, shared by both inference servers.

`build_predict_kwargs` maps request `parameters` onto each predictor's own `predict()` signature via `inspect.signature`. The ONNX server loses its isinstance chain — one code path serves every model type, and new predictor types serve with zero server changes. As a side effect, every predict parameter is now reachable from remote requests (previously only `confidence` was forwarded, so parameters like `nms_threshold` could not be used remotely at all).

Each predictor now builds its own per-image response via `to_response()`; the classification predictor overrides it to keep its historical flat response shape. Response JSON was verified byte-compatible per model type by running the rebuilt container against real production model artifacts and comparing responses.

Debug-image generation — annotate, JPEG-encode, and base64 every image on every request — can now be skipped with `parameters: {"debug_image": false}`. The default stays on so existing clients see no change. This is the single largest serving-latency lever for callers that don't consume the debug images.