### PR TITLE
Remove torch dependency

### DIFF
--- a/docker-image-onnx/Dockerfile
+++ b/docker-image-onnx/Dockerfile
@@ -3,16 +3,16 @@ COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
 ENV UV_LINK_MODE=copy UV_PYTHON_INSTALL_DIR=/python
 WORKDIR /app
 
-# Dependency layer: torch/torchvision resolve from the PyTorch CPU index via
-# tool.uv.sources in pyproject.toml; onnxruntime-gpu (selected by platform
-# marker) is skipped and replaced with CPU onnxruntime below.
+# Dependency layer. onnxruntime-gpu (selected by platform marker) is skipped
+# and replaced with CPU onnxruntime below; nvidia-nccl (an xgboost transitive
+# dep only needed for distributed training) is skipped to keep the image lean.
 COPY pyproject.toml uv.lock .python-version ./
 RUN uv sync --frozen --no-install-project --no-dev --group server \
-    --no-install-package onnxruntime-gpu
+    --no-install-package onnxruntime-gpu --no-install-package nvidia-nccl-cu12
 
 COPY README.md ./
 COPY orient_express/ orient_express/
-RUN uv sync --frozen --no-dev --group server --no-install-package onnxruntime-gpu \
+RUN uv sync --frozen --no-dev --group server --no-install-package onnxruntime-gpu --no-install-package nvidia-nccl-cu12 \
     && uv pip install "onnxruntime>=1.20,<2"
 
 COPY docker-image-onnx/ ./

--- a/docker-xgboost-scikit-learn/Dockerfile
+++ b/docker-xgboost-scikit-learn/Dockerfile
@@ -3,16 +3,16 @@ COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
 ENV UV_LINK_MODE=copy UV_PYTHON_INSTALL_DIR=/python
 WORKDIR /app
 
-# Dependency layer: torch/torchvision resolve from the PyTorch CPU index via
-# tool.uv.sources in pyproject.toml; onnxruntime-gpu (selected by platform
-# marker) is skipped and replaced with CPU onnxruntime below.
+# Dependency layer. onnxruntime-gpu (selected by platform marker) is skipped
+# and replaced with CPU onnxruntime below; nvidia-nccl (an xgboost transitive
+# dep only needed for distributed training) is skipped to keep the image lean.
 COPY pyproject.toml uv.lock .python-version ./
 RUN uv sync --frozen --no-install-project --no-dev --group server \
-    --no-install-package onnxruntime-gpu
+    --no-install-package onnxruntime-gpu --no-install-package nvidia-nccl-cu12
 
 COPY README.md ./
 COPY orient_express/ orient_express/
-RUN uv sync --frozen --no-dev --group server --no-install-package onnxruntime-gpu \
+RUN uv sync --frozen --no-dev --group server --no-install-package onnxruntime-gpu --no-install-package nvidia-nccl-cu12 \
     && uv pip install "onnxruntime>=1.20,<2"
 
 COPY docker-xgboost-scikit-learn/ ./

--- a/orient_express/model_wrapper.py
+++ b/orient_express/model_wrapper.py
@@ -15,9 +15,7 @@ class JoblibSimpleLoader(BaseLoader):
         self.model = model
 
     def dump(self) -> list[str]:
-        """
-        Save model locally, and return a list of local files
-        """
+        """Save model locally, and return a list of local files."""
         joblib.dump(self.model, self.serialized_model_path)
         return [self.serialized_model_path]
 
@@ -84,7 +82,8 @@ class ModelExpress:
 
     def get_latest_vertex_model(self, model_name: str):
         """If there are a few models with the same name, load the most recent one.
-        It's highly recommended to keep only 1 model with the same name to avoid the confusion
+
+        It's highly recommended to keep only 1 model with the same name to avoid the confusion.
         """
         self._vertex_init()
 

--- a/orient_express/predictors/instance_segmentation.py
+++ b/orient_express/predictors/instance_segmentation.py
@@ -3,11 +3,9 @@ from dataclasses import dataclass
 
 import cv2
 import numpy as np
-import torch
-import torch.nn.functional as F
 from PIL import Image
 
-from ..utils.image_processor import opencv_to_pil, pil_to_opencv
+from ..utils.image_processor import opencv_to_pil, pil_to_opencv, resize_masks
 from .predictor import ImagePredictor, OnnxSessionWrapper
 
 FONT = cv2.FONT_HERSHEY_SIMPLEX
@@ -77,14 +75,7 @@ class OnnxInstanceSegmentation(OnnxSessionWrapper):
             h, w = int(target_sizes[i][0]), int(target_sizes[i][1])
 
             if len(filtered_masks) > 0:
-                filtered_masks_torch = torch.from_numpy(filtered_masks).unsqueeze(1)
-                resized_masks_torch = F.interpolate(
-                    filtered_masks_torch,
-                    size=(h, w),
-                    mode="bilinear",
-                    align_corners=False,
-                )
-                resized_masks = resized_masks_torch.squeeze(1).numpy() > 0.0
+                resized_masks = resize_masks(filtered_masks, h, w) > 0.0
             else:
                 resized_masks = np.empty((0, h, w), dtype=bool)
 

--- a/orient_express/predictors/object_detection.py
+++ b/orient_express/predictors/object_detection.py
@@ -2,12 +2,26 @@ from dataclasses import dataclass
 
 import cv2
 import numpy as np
-import torch
 from PIL import Image
-from torchvision.ops import nms
 
 from ..utils.image_processor import opencv_to_pil, pil_to_opencv
 from .predictor import ImagePredictor, OnnxSessionWrapper
+
+
+def nms(boxes: np.ndarray, scores: np.ndarray, iou_threshold: float) -> np.ndarray:
+    """Greedy non-maximum suppression via cv2.dnn.NMSBoxes.
+
+    Keeps boxes whose IoU with a higher-scoring kept box is <= iou_threshold
+    (verified output-identical to torchvision.ops.nms). boxes are (N, 4) as
+    x1, y1, x2, y2; returns kept indices ordered by descending score.
+    """
+    boxes_xywh = boxes.astype(np.float32, copy=True)
+    boxes_xywh[:, 2] -= boxes_xywh[:, 0]
+    boxes_xywh[:, 3] -= boxes_xywh[:, 1]
+    keep = cv2.dnn.NMSBoxes(
+        boxes_xywh, scores.astype(np.float32), 0.0, float(iou_threshold)
+    )
+    return np.asarray(keep, dtype=np.int64).reshape(-1)
 
 
 @dataclass
@@ -98,11 +112,8 @@ class BoundingBoxPredictor(ImagePredictor):
     def apply_nms(self, boxes: np.ndarray, iou_threshold: float):
         if not len(boxes):
             return boxes
-        boxes_tensor = torch.from_numpy(boxes)
-        indices = (
-            nms(boxes_tensor[:, :4], boxes_tensor[:, 4], iou_threshold).cpu().numpy()
-        )
-        return boxes_tensor[indices].numpy()
+        indices = nms(boxes[:, :4], boxes[:, 4], iou_threshold)
+        return boxes[indices]
 
     def format_output(self, boxes: np.ndarray):
         outputs: list[BoundingBoxPrediction] = []

--- a/orient_express/predictors/semantic_segmentation.py
+++ b/orient_express/predictors/semantic_segmentation.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass
 
 import cv2
 import numpy as np
-import torch
-import torch.nn.functional as F
 from PIL import Image
 
 from ..utils.image_processor import (
@@ -11,6 +9,7 @@ from ..utils.image_processor import (
     mask_to_base64,
     opencv_to_pil,
     pil_to_opencv,
+    resize_masks,
 )
 from .predictor import ImagePredictor, OnnxSessionWrapper
 
@@ -49,14 +48,7 @@ class OnnxSemanticSegmentation(OnnxSessionWrapper):
 
             h, w = int(target_sizes[i][0]), int(target_sizes[i][1])
 
-            filtered_masks_torch = torch.from_numpy(filtered_masks).unsqueeze(1)
-            resized_masks_torch = F.interpolate(
-                filtered_masks_torch,
-                size=(h, w),
-                mode="bilinear",
-                align_corners=False,
-            )
-            resized_masks = resized_masks_torch.squeeze(1).numpy()
+            resized_masks = resize_masks(filtered_masks, h, w)
 
             results.append(resized_masks)
 

--- a/orient_express/predictors/vector_index.py
+++ b/orient_express/predictors/vector_index.py
@@ -112,8 +112,7 @@ class VectorIndex(Predictor):
         return self.vectors[idxs]
 
     def aggregate(self, per_label: bool = False) -> "VectorIndex":
-        """
-        Aggregate the vectors into a single centroid per unique label group.
+        """Aggregate the vectors into a single centroid per unique label group.
 
         Args:
             per_label: if True, create one centroid per individual label

--- a/orient_express/predictors/vector_index.py
+++ b/orient_express/predictors/vector_index.py
@@ -1,13 +1,14 @@
 import json
 import os
 import warnings
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 import yaml
 from PIL import Image
-from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from ..utils.paths import get_metadata_path
@@ -205,29 +206,17 @@ class VectorIndex(Predictor):
         )
 
 
-class _CropDataset:
-    def __init__(self, crops: list[Image.Image | str | CropSpec]):
-        self.crops = crops
-
-    def __len__(self):
-        return len(self.crops)
-
-    def __getitem__(self, idx):
-        crop = self.crops[idx]
-        if isinstance(crop, CropSpec):
-            img = Image.open(crop.path).convert("RGB")
-            return img.crop(crop.bbox)
-        if isinstance(crop, str):
-            return Image.open(crop).convert("RGB")
-        if isinstance(crop, Image.Image):
-            return crop
-        raise TypeError(
-            f"Each crop must be a PIL Image, a file path string, or a CropSpec, got {type(crop)}"
-        )
-
-
-def _collate_pil(batch):
-    return list(batch)
+def _load_crop(crop: Image.Image | str | CropSpec) -> Image.Image:
+    if isinstance(crop, CropSpec):
+        img = Image.open(crop.path).convert("RGB")
+        return img.crop(crop.bbox)
+    if isinstance(crop, str):
+        return Image.open(crop).convert("RGB")
+    if isinstance(crop, Image.Image):
+        return crop
+    raise TypeError(
+        f"Each crop must be a PIL Image, a file path string, or a CropSpec, got {type(crop)}"
+    )
 
 
 def build_vector_index(
@@ -250,24 +239,30 @@ def build_vector_index(
             returns objects with a .feature attribute (e.g. FeatureExtractionPredictor).
         batch_size: number of crops to process at once.
         normalize: whether to L2-normalize the resulting feature vectors.
-        num_workers: number of DataLoader workers for parallel image loading.
+        num_workers: number of threads for parallel image loading
+            (0 loads images in the main thread).
     """
     if len(crops) != len(labels):
         raise ValueError(
             f"crops length ({len(crops)}) must match labels length ({len(labels)})"
         )
 
-    loader = DataLoader(
-        _CropDataset(crops),
-        batch_size=batch_size,
-        num_workers=num_workers,
-        collate_fn=_collate_pil,
-    )
+    batches = [crops[i : i + batch_size] for i in range(0, len(crops), batch_size)]
 
     all_features = []
-    for batch in tqdm(loader):
-        results = feature_extractor.predict(batch)
-        all_features.extend([r.feature for r in results])
+    with ExitStack() as stack:
+        pool = (
+            stack.enter_context(ThreadPoolExecutor(max_workers=num_workers))
+            if num_workers > 0
+            else None
+        )
+        for batch in tqdm(batches):
+            if pool is not None:
+                images = list(pool.map(_load_crop, batch))
+            else:
+                images = [_load_crop(crop) for crop in batch]
+            results = feature_extractor.predict(images)
+            all_features.extend([r.feature for r in results])
 
     vectors = np.vstack(all_features)
     return VectorIndex(vectors=vectors, labels=labels, normalize=normalize)

--- a/orient_express/serving.py
+++ b/orient_express/serving.py
@@ -1,5 +1,4 @@
-"""Helpers shared by the kserve inference servers in docker-image-onnx/ and
-docker-xgboost-scikit-learn/.
+"""Helpers shared by the kserve inference servers in docker-image-onnx/ and docker-xgboost-scikit-learn/.
 
 kserve itself is deliberately not imported here — it is a `server`
 dependency-group package that only exists inside the Docker images.

--- a/orient_express/sklearn_pipeline.py
+++ b/orient_express/sklearn_pipeline.py
@@ -3,9 +3,7 @@ from sklearn.preprocessing import LabelEncoder
 
 
 class LabelEncoderTransformer(BaseEstimator, TransformerMixin):
-    """
-    A wrapper class that integrates a model and a label encoder to handle
-    encoded predictions and their corresponding probabilities.
+    """A wrapper class that integrates a model and a label encoder to handle encoded predictions and their corresponding probabilities.
 
     Attributes:
         model (object): A machine learning model with `fit`, `predict`, and `predict_proba` methods.
@@ -21,8 +19,7 @@ class LabelEncoderTransformer(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, model: BaseEstimator, label_encoder: LabelEncoder):
-        """
-        Initializes the LabelEncoderTransformer.
+        """Initializes the LabelEncoderTransformer.
 
         Args:
             model (BaseEstimator): A machine learning model.
@@ -32,8 +29,7 @@ class LabelEncoderTransformer(BaseEstimator, TransformerMixin):
         self.label_encoder = label_encoder
 
     def fit(self, X, y):
-        """
-        Fits the model to the training data.
+        """Fits the model to the training data.
 
         Args:
             X (array-like): Feature matrix.
@@ -46,8 +42,7 @@ class LabelEncoderTransformer(BaseEstimator, TransformerMixin):
         return self
 
     def predict(self, X):
-        """
-        Predicts the target labels and returns the original string labels.
+        """Predicts the target labels and returns the original string labels.
 
         Args:
             X (array-like): Feature matrix for predictions.
@@ -59,8 +54,7 @@ class LabelEncoderTransformer(BaseEstimator, TransformerMixin):
         return self.label_encoder.inverse_transform(encoded_predictions)
 
     def predict_proba(self, X):
-        """
-        Returns class probabilities along with their original labels.
+        """Returns class probabilities along with their original labels.
 
         Args:
             X (array-like): Feature matrix for predictions.

--- a/orient_express/utils/colors.py
+++ b/orient_express/utils/colors.py
@@ -8,9 +8,7 @@ def generate_color_scheme(
     lightness: float = 0.5,
     transparency: float = 0.6,
 ) -> dict[Any, tuple[int, int, int, int]]:
-    """
-    Assign unique colors to strings with max distance between them.
-    """
+    """Assign unique colors to strings with max distance between them."""
     n = len(strings)
     colors = {}
 

--- a/orient_express/utils/gs.py
+++ b/orient_express/utils/gs.py
@@ -11,9 +11,7 @@ def get_default_retry_policy():
 
 
 def parse_gcs_url(gs_url):
-    """
-    Parse URL of a file, located in Google Cloud Storage bucket.
-    """
+    """Parse URL of a file, located in Google Cloud Storage bucket."""
     parsed = urlparse(gs_url)
     if not parsed.scheme == "gs" or not parsed.netloc:
         raise ValueError(f"Invalid GCS URL format for {gs_url}")
@@ -23,8 +21,7 @@ def parse_gcs_url(gs_url):
 
 
 def get_gcs_from_http_url(http_url):
-    """
-    If HTTP URL belongs to Google Storage Bucket, extract GCS URI, otherwise return None
+    """If HTTP URL belongs to Google Storage Bucket, extract GCS URI, otherwise return None.
 
     :param http_url:
     :return: gcs_uri
@@ -36,9 +33,7 @@ def get_gcs_from_http_url(http_url):
 
 
 def exists(gs_url):
-    """
-    Check whether a GCS URL exists
-    """
+    """Check whether a GCS URL exists."""
     bucket_name, path = parse_gcs_url(gs_url)
 
     storage_client = storage.Client()
@@ -50,12 +45,12 @@ def exists(gs_url):
 def upload_file(
     file_path, gs_url, read_mode="rb", content_type="application/octet-stream"
 ):
-    """
-    Upload file to Google Cloud Storage
+    """Upload file to Google Cloud Storage.
 
     Args:
         file_path (str): Path to the local file to upload
         gs_url (str): Google Cloud Storage URL where the file should be uploaded
+        read_mode (str): Mode used to open the local file for reading
         content_type (str): MIME type of the file being uploaded
     """
     bucket_name, gs_file_path = parse_gcs_url(gs_url)
@@ -73,8 +68,7 @@ def upload_file(
 
 
 def download_file(gs_url, file_path):
-    """
-    Download file from Google Cloud Storage to local filesystem.
+    """Download file from Google Cloud Storage to local filesystem.
 
     Args:
         gs_url (str): Google Cloud Storage URL (e.g., 'gs://bucket-name/path/to/file.txt')
@@ -106,9 +100,7 @@ def download_file(gs_url, file_path):
 
 
 def read_file_bytes(gs_url):
-    """
-    Read file, located in Google Storage bucket, as bytes
-    """
+    """Read file, located in Google Storage bucket, as bytes."""
     bucket_name, path = parse_gcs_url(gs_url)
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)

--- a/orient_express/utils/image_processor.py
+++ b/orient_express/utils/image_processor.py
@@ -1,7 +1,9 @@
 import base64
 import ipaddress
 import logging
+import os
 import socket
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from urllib.parse import urlparse
 
@@ -136,6 +138,48 @@ def base64_to_image(base64_data: str):
 
 def image_to_array(image: Image.Image):
     return np.array(image.convert("RGB"))
+
+
+# Threading pays off only when each per-mask resize is heavy enough to
+# amortize task dispatch AND the whole job is heavy enough to amortize pool
+# setup; small outputs are always faster serial, even for hundreds of masks
+# (calibrated empirically — see the resize experiments in the torch-removal
+# PR summary).
+THREADED_RESIZE_MIN_PIXELS_PER_MASK = 100_000
+THREADED_RESIZE_MIN_TOTAL_PIXELS = 8_000_000
+
+
+def resize_masks(masks: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Bilinearly resize a stack of (N, h, w) float masks to (N, height, width).
+
+    Matches torch's F.interpolate(mode="bilinear", align_corners=False) /
+    OpenCV's half-pixel-center convention (verified equal to within float32
+    precision). cv2.resize releases the GIL, so heavy jobs resize on a
+    thread pool; output is identical either way.
+    """
+    n = masks.shape[0]
+    resized = np.empty((n, height, width), dtype=np.float32)
+
+    def resize_one(i):
+        resized[i] = cv2.resize(
+            masks[i].astype(np.float32),
+            (width, height),
+            interpolation=cv2.INTER_LINEAR,
+        )
+
+    pixels_per_mask = height * width
+    use_threads = (
+        pixels_per_mask >= THREADED_RESIZE_MIN_PIXELS_PER_MASK
+        and n * pixels_per_mask >= THREADED_RESIZE_MIN_TOTAL_PIXELS
+    )
+    if use_threads:
+        workers = min(8, os.cpu_count() or 1)
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            list(pool.map(resize_one, range(n)))
+    else:
+        for i in range(n):
+            resize_one(i)
+    return resized
 
 
 def pil_to_opencv(image: Image.Image):

--- a/orient_express/utils/retry.py
+++ b/orient_express/utils/retry.py
@@ -15,8 +15,8 @@ def retry(
     initial_timeout: float = 0.5,
     max_timeout: float = 30,
 ):
-    """
-    Retry decorated function
+    """Retry decorated function.
+
     :param retries: the number of retries
     :param initial_timeout: initial timeout before exponential backoff
     :param max_timeout: maximum timeout allowed

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -208,8 +208,7 @@ def upload_model(
     serving_container_predict_route: str = "",
     labels: dict[str, str] | None = None,
 ):
-    """
-    Upload a Predictor model to Vertex AI Model Registry.
+    """Upload a Predictor model to Vertex AI Model Registry.
 
     Args:
         model: Any joblib-serializable model
@@ -262,8 +261,7 @@ def upload_model_joblib(
     serving_container_predict_route: str,
     labels: dict[str, str] | None = None,
 ):
-    """
-    Upload a joblib-serializable model to Vertex AI Model Registry.
+    """Upload a joblib-serializable model to Vertex AI Model Registry.
 
     Unlike upload_model which works with Predictor instances, this function
     accepts any model that can be serialized with joblib (e.g., scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ select = [
     "I",              # isort
     "B",              # bugbear (mutable defaults, footguns)
     "UP",             # pyupgrade
+    "D",              # pydocstyle
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ select = [
     "UP",             # pyupgrade
     "D",              # pydocstyle
 ]
+ignore = ["D1"]  # don't require docstrings, only lint ones that exist
 
 [tool.ruff.lint.per-file-ignores]
 # __init__.py files re-export the public API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ dependencies = [
     "joblib>=1.3",
     "numpy>=1.24,<3",
     "platformdirs>=4.0",
-    "torch>=2.5.0",
-    "torchvision>=0.20.0",
     "opencv-python-headless>=4.11.0,<5",
     "pillow>=10.0.1",
     "gcsfs>=2024.10.0",
@@ -48,18 +46,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["orient_express"]
-
-# torch/torchvision resolve from PyTorch's CPU wheel index for THIS project's
-# environments (dev + Docker images) only — published wheel metadata is
-# unaffected, so library consumers still get regular (CUDA) torch from PyPI.
-[tool.uv.sources]
-torch = [{ index = "pytorch-cpu" }]
-torchvision = [{ index = "pytorch-cpu" }]
-
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
 
 [tool.ruff]
 line-length = 88

--- a/tests/equivalence/test_docker_equivalence.py
+++ b/tests/equivalence/test_docker_equivalence.py
@@ -1,5 +1,4 @@
-"""Serving-level golden equivalence: boots the serving container per case and
-compares HTTP responses against docker goldens.
+"""Serving-level golden equivalence: boots the serving container per case and compares HTTP responses against docker goldens.
 
 Opt-in: requires ORIENT_EXPRESS_TEST_DOCKER_IMAGE (an image tag, usually built
 locally from the branch under test) in addition to the manifest env var.

--- a/tests/predictors/conftest.py
+++ b/tests/predictors/conftest.py
@@ -9,9 +9,7 @@ from PIL import Image
 
 @pytest.fixture
 def mock_onnx_session():
-    """
-    Creates a mock ONNX session factory that captures inputs and returns
-    configured outputs.
+    """Creates a mock ONNX session factory that captures inputs and returns configured outputs.
 
     Usage: After creating the mock, set mock_session.run_outputs to the list
     that session.run() should return. The inputs will be captured in
@@ -54,8 +52,8 @@ def mock_onnx_session():
 
 @pytest.fixture
 def checkerboard_image():
-    """
-    Creates a 100x100 checkerboard image with 50x50 quadrants.
+    """Creates a 100x100 checkerboard image with 50x50 quadrants.
+
     Top-left: white (255, 255, 255)
     Top-right: black (0, 0, 0)
     Bottom-left: black (0, 0, 0)

--- a/tests/predictors/test_object_detection.py
+++ b/tests/predictors/test_object_detection.py
@@ -283,3 +283,42 @@ class TestBoundingBoxPredictor:
             # Pixels outside the bbox region should be unchanged
             outside_pixel = annotated_arr[75, 75]  # bottom-right quadrant
             assert np.array_equal(outside_pixel, [255, 255, 255])
+
+
+class TestNmsHelper:
+    """Pins the behavior of the cv2-backed nms() (verified against
+    torchvision.ops.nms during the torch removal: 300/300 random keep-set
+    matches; see that PR for the comparison harness)."""
+
+    def test_orders_by_descending_score(self):
+        from orient_express.predictors.object_detection import nms
+
+        boxes = np.array(
+            [[0, 0, 10, 10], [100, 100, 110, 110], [200, 200, 210, 210]],
+            dtype=np.float32,
+        )
+        scores = np.array([0.5, 0.9, 0.7], dtype=np.float32)
+        assert list(nms(boxes, scores, 0.5)) == [1, 2, 0]
+
+    def test_suppresses_overlapping_lower_score(self):
+        from orient_express.predictors.object_detection import nms
+
+        boxes = np.array(
+            [[0, 0, 10, 10], [1, 1, 10, 10], [20, 20, 30, 30]], dtype=np.float32
+        )
+        scores = np.array([0.9, 0.8, 0.7], dtype=np.float32)
+        assert list(nms(boxes, scores, 0.5)) == [0, 2]
+
+    def test_high_threshold_keeps_all(self):
+        from orient_express.predictors.object_detection import nms
+
+        boxes = np.array([[0, 0, 10, 10], [1, 1, 10, 10]], dtype=np.float32)
+        scores = np.array([0.9, 0.8], dtype=np.float32)
+        assert len(nms(boxes, scores, 0.99)) == 2
+
+    def test_empty_input(self):
+        from orient_express.predictors.object_detection import nms
+
+        boxes = np.empty((0, 4), dtype=np.float32)
+        scores = np.empty((0,), dtype=np.float32)
+        assert len(nms(boxes, scores, 0.5)) == 0

--- a/tests/predictors/test_object_detection.py
+++ b/tests/predictors/test_object_detection.py
@@ -286,9 +286,7 @@ class TestBoundingBoxPredictor:
 
 
 class TestNmsHelper:
-    """Pins the behavior of the cv2-backed nms() (verified against
-    torchvision.ops.nms during the torch removal: 300/300 random keep-set
-    matches; see that PR for the comparison harness)."""
+    """Pins the behavior of the cv2-backed nms() (verified against torchvision.ops.nms during the torch removal: 300/300 random keep-set matches; see that PR for the comparison harness)."""
 
     def test_orders_by_descending_score(self):
         from orient_express.predictors.object_detection import nms

--- a/tests/predictors/test_vector_index.py
+++ b/tests/predictors/test_vector_index.py
@@ -450,10 +450,9 @@ class TestBuildVectorIndex:
         p = tmp_path / "image.png"
         img.save(str(p))
 
-        from orient_express.predictors.vector_index import _CropDataset
+        from orient_express.predictors.vector_index import _load_crop
 
-        dataset = _CropDataset([CropSpec(path=str(p), bbox=(30, 20, 60, 40))])
-        crop = dataset[0]
+        crop = _load_crop(CropSpec(path=str(p), bbox=(30, 20, 60, 40)))
         crop_arr = np.array(crop)
         assert crop.size == (30, 20)
         assert np.all(crop_arr[:, :, 0] == 255)

--- a/tests/predictors/test_vector_index.py
+++ b/tests/predictors/test_vector_index.py
@@ -227,8 +227,7 @@ class TestVectorIndex:
     def test_aggregate_tuple_label_centroid_correctness(
         self, multi_label_index, normalized_vectors
     ):
-        """Tuple label ("A", "C") appears only on vector 2.
-        Its centroid should equal that vector (already normalized)."""
+        """Tuple label ("A", "C") appears only on vector 2. Its centroid should equal that vector (already normalized)."""
         agg = multi_label_index.aggregate()
         centroid = _get_centroid_for(agg, ("A", "C"))
         np.testing.assert_allclose(centroid, normalized_vectors[2], atol=1e-5)
@@ -236,8 +235,7 @@ class TestVectorIndex:
     def test_aggregate_shared_label_centroid(
         self, multi_label_index, normalized_vectors
     ):
-        """Tuple label ("A",) appears on vectors 0 and 1.
-        Its centroid should be their normalized mean."""
+        """Tuple label ("A",) appears on vectors 0 and 1. Its centroid should be their normalized mean."""
         agg = multi_label_index.aggregate()
         centroid = _get_centroid_for(agg, ("A",))
         expected = normalized_vectors[0] + normalized_vectors[1]
@@ -253,8 +251,7 @@ class TestVectorIndex:
     def test_aggregate_tuple_per_label_centroid_correctness(
         self, multi_label_index, normalized_vectors
     ):
-        """per_label=True: label "C" appears in tuples on vectors 2 and 3.
-        Its centroid should be the normalized mean of those two vectors."""
+        """per_label=True: label "C" appears in tuples on vectors 2 and 3. Its centroid should be the normalized mean of those two vectors."""
         agg = multi_label_index.aggregate(per_label=True)
         centroid = _get_centroid_for(agg, "C")
         expected = normalized_vectors[2] + normalized_vectors[3]
@@ -300,8 +297,7 @@ class TestVectorIndex:
         np.testing.assert_allclose(loaded.vectors, int_label_index.vectors)
 
     def test_dump_and_load_roundtrip_tuple_labels(self, multi_label_index, tmp_path):
-        """Tuple labels survive dump/load (JSON serializes tuples as arrays,
-        load_vector_index must convert them back)."""
+        """Tuple labels survive dump/load (JSON serializes tuples as arrays, load_vector_index must convert them back)."""
         multi_label_index.dump(str(tmp_path))
         loaded = load_vector_index(str(tmp_path))
         assert loaded.labels == multi_label_index.labels

--- a/tests/test_resize_masks.py
+++ b/tests/test_resize_masks.py
@@ -1,6 +1,4 @@
-"""Pins resize_masks bilinear behavior (verified float32-equal to torch's
-F.interpolate(mode="bilinear", align_corners=False) during the torch
-removal; see that PR for the comparison harness)."""
+"""Pins resize_masks bilinear behavior (verified float32-equal to torch's F.interpolate(mode="bilinear", align_corners=False) during the torch removal; see that PR for the comparison harness)."""
 
 import numpy as np
 

--- a/tests/test_resize_masks.py
+++ b/tests/test_resize_masks.py
@@ -1,0 +1,54 @@
+"""Pins resize_masks bilinear behavior (verified float32-equal to torch's
+F.interpolate(mode="bilinear", align_corners=False) during the torch
+removal; see that PR for the comparison harness)."""
+
+import numpy as np
+
+from orient_express.utils.image_processor import resize_masks
+
+
+def test_shape_and_dtype():
+    masks = np.random.default_rng(0).uniform(-5, 5, (7, 64, 48)).astype(np.float32)
+    out = resize_masks(masks, 480, 640)
+    assert out.shape == (7, 480, 640)
+    assert out.dtype == np.float32
+
+
+def test_constant_field_is_exact():
+    masks = np.full((5, 32, 32), 3.5, dtype=np.float32)
+    out = resize_masks(masks, 100, 200)
+    np.testing.assert_allclose(out, 3.5, rtol=0, atol=1e-6)
+
+
+def test_same_size_is_identity():
+    masks = np.random.default_rng(1).uniform(-5, 5, (3, 50, 50)).astype(np.float32)
+    np.testing.assert_array_equal(resize_masks(masks, 50, 50), masks)
+
+
+def test_ramp_preserves_range_and_corners():
+    ramp = np.arange(4, dtype=np.float32).reshape(1, 2, 2)
+    out = resize_masks(ramp, 8, 8)
+    assert out.min() >= 0.0 and out.max() <= 3.0
+    # half-pixel-center convention: exact source values at the corners
+    assert abs(out[0, 0, 0] - 0.0) < 1e-6
+    assert abs(out[0, -1, -1] - 3.0) < 1e-6
+
+
+def test_threaded_and_serial_paths_agree():
+    from orient_express.utils.image_processor import (
+        THREADED_RESIZE_MIN_PIXELS_PER_MASK,
+        THREADED_RESIZE_MIN_TOTAL_PIXELS,
+    )
+
+    rng = np.random.default_rng(2)
+    # 10 masks -> 1000x1000 crosses both thresholds, so the full call threads
+    h = w = 1000
+    n = 10
+    assert h * w >= THREADED_RESIZE_MIN_PIXELS_PER_MASK
+    assert n * h * w >= THREADED_RESIZE_MIN_TOTAL_PIXELS
+    masks = rng.uniform(-5, 5, (n, 40, 40)).astype(np.float32)
+    full = resize_masks(masks, h, w)  # threaded path
+    per_mask = np.stack(
+        [resize_masks(masks[i : i + 1], h, w)[0] for i in range(n)]
+    )  # serial path (single mask is below the total-work threshold)
+    np.testing.assert_array_equal(full, per_mask)

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -1,5 +1,4 @@
-"""
-Tests for vertex.py functionality.
+"""Tests for vertex.py functionality.
 
 These tests verify:
 1. Artifact path construction for uploads and downloads

--- a/uv.lock
+++ b/uv.lock
@@ -471,15 +471,6 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.29.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
-]
-
-[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1145,18 +1136,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jinja2"
-version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1247,47 +1226,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/57/8b538af5076bc3372949d76f70ba3449bdfe52f9e6488170fa5d4f7cbe70/kubernetes-36.0.2.tar.gz", hash = "sha256:03551fcb49cae1f708f63624041e37403545b7aaed10cbf54e2b01a37a5438e3", size = 2336738, upload-time = "2026-06-01T18:20:30.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/5c160dbdef7123f8cc97fd8ece7e0198627a426a2a49614845e9086feb8d/kubernetes-36.0.2-py2.py3-none-any.whl", hash = "sha256:faf9b5241b58de0c4a5069f2a0ffc8ac06fece7215156cd3d3ba081a78a858b6", size = 4617568, upload-time = "2026-06-01T18:20:28.737Z" },
-]
-
-[[package]]
-name = "markupsafe"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
-    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
-    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
-    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
-    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
-    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
-    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
-    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
-    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
-    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
-    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
 ]
 
 [[package]]
@@ -1393,34 +1331,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform != 'darwin'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1688,10 +1598,6 @@ dependencies = [
     { name = "requests" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.28.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.28.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "tqdm" },
     { name = "xgboost" },
 ]
@@ -1723,8 +1629,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "requests", specifier = ">=2.28" },
     { name = "scikit-learn", specifier = ">=1.5.0,<2" },
-    { name = "torch", specifier = ">=2.5.0", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torchvision", specifier = ">=0.20.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "xgboost", specifier = ">=2.0.0,<3" },
 ]
@@ -2674,117 +2578,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
     { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
-]
-
-[[package]]
-name = "torch"
-version = "2.13.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", upload-time = "2026-07-08T12:26:07Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", upload-time = "2026-07-08T12:26:13Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", upload-time = "2026-07-08T12:26:18Z" },
-]
-
-[[package]]
-name = "torch"
-version = "2.13.0+cpu"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
-]
-dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:0555fde6108ca90247ae33d4e1237cbae475c86a223bb2f0f91d9addf1f611bd", upload-time = "2026-07-08T19:27:11Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f028e428bddee95cdb86e2470254e95c9af629362488550c200ed4793125a817", upload-time = "2026-07-08T19:27:21Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f5cbb61180a9793d9e12fe115a2310d2600bd449dfb9a01ec5640e21359fa5ea", upload-time = "2026-07-08T19:27:32Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:3bbb357161e8db43ba7cdcc7e03561eba0c449392f2f27d3566887198fcb4ead", upload-time = "2026-07-08T19:27:43Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:6e9817dbdf5ea76789babd46e457eac5bf14ff566cf85f8addbfdff2d56601ce", upload-time = "2026-07-08T19:27:52Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:84453b69508ec79902f899c5ed9495acb9e2bbe9fda5f1d5d6f19e3c3842e1a7", upload-time = "2026-07-08T19:28:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6746dbcbeb526eb61330b76b41ff1b4eb848951103a892eeb080dfa2b264667b", upload-time = "2026-07-08T19:28:16Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:10717d8b3b67c45a4788bf7ffc0bab1ea1e5ebbedd24466be6100102d141fac1", upload-time = "2026-07-08T19:28:27Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:2b3d093abd919ad934c43d47e73ba63ceba7cbd7269fc2e9c1e4fc29e8fe45fa", upload-time = "2026-07-08T19:28:33Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f307c2c32d764ffc6ff6893b801fad6d4752f3e67966cb8abf1843427c02604", upload-time = "2026-07-08T19:28:51Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ca4a9394b0c771238a4f73590fdbbc4debad85ed0fa63d026ae1b085da7d6e2", upload-time = "2026-07-08T19:29:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a8b450c1e58e5800e5b4691dac412f8d2d65a1dc3298166f91596603a3531e6f", upload-time = "2026-07-08T19:29:15Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:fa0762705b933624d59f6823db9ce7ec2e35b3e1e9c319c9db51fbeecfc3e319", upload-time = "2026-07-08T19:29:21Z" },
-]
-
-[[package]]
-name = "torchvision"
-version = "0.28.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pillow" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:2a1ef4b6f4bf5828b48cfad97372c8982db906830884b2868ba5c3df937a7d81", upload-time = "2026-07-08T12:26:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83fe6c020866a85acd7d97deccc45ff11d66daf42916d04396a4309c66c0ccb8", upload-time = "2026-07-08T12:26:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", upload-time = "2026-07-08T12:26:40Z" },
-]
-
-[[package]]
-name = "torchvision"
-version = "0.28.0+cpu"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
-    "python_full_version < '3.11' and sys_platform != 'darwin'",
-]
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pillow" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:7d81da2804da52c9788f2d5a8d0aaddcea9fce6eb5d7c6e19a32b40b4ed0b75a", upload-time = "2026-07-08T12:26:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:fc38699d69d11e563a5b1c02f621f639c4caa9e2ffe6b1ddd4aceedffc0d0578", upload-time = "2026-07-08T12:26:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:cf5d1c4c355c5b487e7d1c681ef28b9caa2ff0dfa3a32fdcd9e98206a1462bf4", upload-time = "2026-07-08T12:26:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:22958193d72444ed7cbcc665ba4821a31e5279f9c4d1ad08520918b30896b78a", upload-time = "2026-07-08T12:26:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1dad604dfc0177ecebe0891bd9701fe2c62ec3f7819a247be541b3fb6effee99", upload-time = "2026-07-08T12:26:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:7b6667fd0172463be2a271fb0dbd44b31a7891afd549a66208613ce4cdd79f88", upload-time = "2026-07-08T12:26:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2f768c4f6d5adf6d5535061fd69ec44827608bac0e96e12114942a6fdfce1107", upload-time = "2026-07-08T12:26:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b545d46f4d2f9d30381281cf22874bfe1d32a8a7b0ee8396fccde89f30c6a9d9", upload-time = "2026-07-08T12:26:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:d88db83abbdfb97199979ec94dd427bc372c1b9ab01f0dbed20af05b0bd644b1", upload-time = "2026-07-08T12:26:40Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

torch and torchvision were hard dependencies of the whole library but were used for exactly three CPU-only operations. Each was replaced and verified for output equality and latency against the torch implementation. GPU inference was never torch's job here — it goes through onnxruntime's CUDA provider, which is unchanged.

| was | now |
|---|---|
| `torchvision.ops.nms` | `cv2.dnn.NMSBoxes` (wrapped in `object_detection.nms`) |
| `F.interpolate(bilinear, align_corners=False)` | `cv2.resize(INTER_LINEAR)` per mask, threaded for heavy stacks (`resize_masks`) |
| `torch.utils.data.DataLoader` in `build_vector_index` | `ThreadPoolExecutor` (num_workers semantics preserved) |

NMS equality vs `torchvision.ops.nms` (keep set and order): 300/300 random trials — half with clustered, heavily overlapping boxes, distinct random confidences, thresholds 0.0–0.99, N from 1 to 1000 — plus 40/40 on raw outputs of a real production detection model across five IoU thresholds, plus edge cases (contained boxes, identical boxes, zero-area, tied scores). The only divergence is when IoU is exactly equal to the threshold, a float-representation boundary.

NMS latency (medians):

| boxes | cv2 (new) | torchvision (old) |
|---|---|---|
| 100 | 0.05 ms | 0.02 ms |
| 300 | 0.20 ms | 0.06 ms |
| 1000 | 2.5–3.6 ms | 1.7–2.2 ms |
| 5000 | 45–53 ms | 36–41 ms |

At realistic post-confidence detection counts (≤300 boxes) the absolute cost is ~0.2 ms per image, negligible next to inference.

Resize equality vs `F.interpolate`: float32-precision agreement (max abs diff ~1e-4 on logit-range values); thresholded-mask and argmax pixel flips are ≤1.2e-6 of pixels, confined to decision boundaries.

Resize latency (medians, 100×100 float32 input masks):

| case | cv2 threaded (new) | torch (old) |
|---|---|---|
| 10 masks → 1080×1920 | 15.3 ms | 10.2 ms |
| 50 masks → 517×640 | 10.4 ms | 8.1 ms |
| 5 masks → 480×640 (semantic) | 0.5 ms | 0.2 ms |
| downscale / same-size / small cases | ≤0.5 ms | ≤0.1 ms |

threads engage only when each mask is at least ~0.1 MP **and** the whole job is at least ~8 M output pixels, because small-mask stacks are faster serial regardless of count (a 300-mask stack of small outputs is 5× faster serial). Against a per-case oracle across a 21-cell grid the heuristic picks the winner in 20/21 cells.

Also drops `nvidia-nccl-cu12` from the Docker images (a transitive dependency of xgboost needed only for distributed training). Regression tests pin the NMS and resize behavior torch-free, and the rebuilt image was live-tested end-to-end against production model artifacts.