### PR TITLE
Single-copy PIL-to-array conversion

### DIFF
--- a/orient_express/predictors/instance_segmentation.py
+++ b/orient_express/predictors/instance_segmentation.py
@@ -60,9 +60,7 @@ class OnnxInstanceSegmentation(OnnxSessionWrapper):
         }
 
         boxes, scores, labels, masks = self.session.run(None, input_dict)
-        return self.postprocess(
-            boxes, scores, labels, masks, target_sizes_array, confidence
-        )
+        return self.postprocess(boxes, scores, labels, masks, confidence)
 
     def postprocess(
         self,
@@ -70,7 +68,6 @@ class OnnxInstanceSegmentation(OnnxSessionWrapper):
         scores: np.ndarray,
         labels: np.ndarray,
         masks: np.ndarray,
-        target_sizes: np.ndarray,
         confidence: float,
     ):
         results: list[tuple[np.ndarray, np.ndarray]] = []

--- a/orient_express/utils/image_processor.py
+++ b/orient_express/utils/image_processor.py
@@ -138,7 +138,18 @@ def base64_to_image(base64_data: str):
 
 
 def image_to_array(image: Image.Image):
-    return np.array(image.convert("RGB"))
+    """PIL -> HxWx3 uint8 RGB array with a single full-resolution copy.
+
+    The obvious np.array(image.convert("RGB")) materializes three
+    full-resolution temporaries (convert copy + tobytes + array copy), which
+    is page-fault-bound on large photos (~40 ms at 4K vs ~4 ms here). The
+    returned array is read-only; callers that need to write should copy.
+    """
+    if image.mode != "RGB":
+        image = image.convert("RGB")
+    return np.frombuffer(image.tobytes(), dtype=np.uint8).reshape(
+        image.height, image.width, 3
+    )
 
 
 # Threading pays off only when each per-mask resize is heavy enough to

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -4,7 +4,11 @@ import os
 import tempfile
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+<<<<<<< HEAD
 from typing import TYPE_CHECKING, Any, TypeVar, overload
+=======
+from typing import Any, TypeVar, overload
+>>>>>>> f794b3a (Add predictor registry and typed loading)
 
 import joblib
 import yaml
@@ -13,9 +17,12 @@ from google.cloud.storage import transfer_manager
 
 from .utils.paths import get_cache_dir
 
+<<<<<<< HEAD
 if TYPE_CHECKING:
     from .predictors import Predictor
 
+=======
+>>>>>>> f794b3a (Add predictor registry and typed loading)
 T = TypeVar("T")
 
 ARTIFACT_DIR = get_cache_dir()
@@ -131,9 +138,12 @@ class VertexModel:
                 expected_type=BoundingBoxPredictor
             )
         """
+<<<<<<< HEAD
         # Deferred: pulls onnxruntime/cv2, which vertex-only users never need
         from .predictors import get_predictor
 
+=======
+>>>>>>> f794b3a (Add predictor registry and typed loading)
         dir = os.path.join(ARTIFACT_DIR, self.model_name + "-" + str(self.version))
         self.download_artifacts(dir, force_download=force_download)
         if expected_type is None:

--- a/orient_express/vertex.py
+++ b/orient_express/vertex.py
@@ -4,11 +4,7 @@ import os
 import tempfile
 import warnings
 from concurrent.futures import ThreadPoolExecutor
-<<<<<<< HEAD
 from typing import TYPE_CHECKING, Any, TypeVar, overload
-=======
-from typing import Any, TypeVar, overload
->>>>>>> f794b3a (Add predictor registry and typed loading)
 
 import joblib
 import yaml
@@ -17,12 +13,9 @@ from google.cloud.storage import transfer_manager
 
 from .utils.paths import get_cache_dir
 
-<<<<<<< HEAD
 if TYPE_CHECKING:
     from .predictors import Predictor
 
-=======
->>>>>>> f794b3a (Add predictor registry and typed loading)
 T = TypeVar("T")
 
 ARTIFACT_DIR = get_cache_dir()
@@ -138,12 +131,9 @@ class VertexModel:
                 expected_type=BoundingBoxPredictor
             )
         """
-<<<<<<< HEAD
         # Deferred: pulls onnxruntime/cv2, which vertex-only users never need
         from .predictors import get_predictor
 
-=======
->>>>>>> f794b3a (Add predictor registry and typed loading)
         dir = os.path.join(ARTIFACT_DIR, self.model_name + "-" + str(self.version))
         self.download_artifacts(dir, force_download=force_download)
         if expected_type is None:

--- a/tests/test_resize_masks.py
+++ b/tests/test_resize_masks.py
@@ -50,3 +50,20 @@ def test_threaded_and_serial_paths_agree():
         [resize_masks(masks[i : i + 1], h, w)[0] for i in range(n)]
     )  # serial path (single mask is below the total-work threshold)
     np.testing.assert_array_equal(full, per_mask)
+
+
+def test_image_to_array_single_copy_path_matches_reference():
+    """image_to_array must stay bit-identical to np.array(img.convert('RGB'))."""
+    from PIL import Image
+
+    from orient_express.utils.image_processor import image_to_array
+
+    rng = np.random.default_rng(3)
+    rgb = Image.fromarray(rng.integers(0, 255, (60, 40, 3), dtype=np.uint8))
+    np.testing.assert_array_equal(image_to_array(rgb), np.array(rgb.convert("RGB")))
+
+    rgba = rgb.convert("RGBA")
+    np.testing.assert_array_equal(image_to_array(rgba), np.array(rgba.convert("RGB")))
+
+    gray = rgb.convert("L")
+    np.testing.assert_array_equal(image_to_array(gray), np.array(gray.convert("RGB")))


### PR DESCRIPTION
`image.convert("RGB")` is an unnecessary copy when the image is already in RGB mode. 

`image_to_array` now skips `convert` when the mode is already RGB and wraps `tobytes()` in a zero-copy `np.frombuffer(...).reshape(...)`, producing one full-resolution copy instead of three. The returned array is read-only; both internal consumers (`cv2.resize`, `cv2.cvtColor`) only read it.

Full `predict` per image (medians, provider verified per run) at (2160×3840):

| model | CPU before → after | CUDA (5090) before → after |
|---|---|---|
| detection | 174.8 → 128.3 ms | 41.9 → **8.8 ms** (4.8×) |
| instance segmentation | 249.9 → 195.6 ms | 43.5 → **9.6 ms** (4.5×) |
| classification | 80.5 → 28.9 ms (2.8×) | 39.9 → **6.6 ms** (6.0×) |
| semantic segmentation | 304.1 → 271.7 ms | 164.6 → 128.1 ms |
| multi-label classification | 248.9 → 232.3 ms | 15.2 → 10.9 ms |
| feature extraction (small crops) | 17.0 → 18.1 ms | ~2 ms (unchanged) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance-segmentation result processing by consistently filtering detections and associated masks according to the confidence threshold.
  * Ensured image conversion consistently produces RGB pixel data across common image formats.

* **Performance**
  * Reduced unnecessary image-data copying during processing, improving memory efficiency.

* **Tests**
  * Added coverage confirming converted pixel values remain identical across RGB, RGBA, and grayscale images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->