### PR TITLE
Reduce dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "google-cloud-aiplatform>=1.0,<2",
     "google-cloud-storage>=3.0,<4",
-    "pandas>=2.0,<3",
     "pyyaml>=6.0,<7",
     "requests>=2.28",
     "joblib>=1.3",
@@ -19,9 +18,6 @@ dependencies = [
     "platformdirs>=4.0",
     "opencv-python-headless>=4.11.0,<5",
     "pillow>=10.0.1",
-    "gcsfs>=2024.10.0",
-    "scikit-learn>=1.5.0,<2",
-    "xgboost>=2.0.0,<3",
     "tqdm>=4.67.1",
     "onnxruntime-gpu>=1.20,<2 ; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64')",
     "onnxruntime>=1.20,<2 ; sys_platform == 'darwin' or platform_machine == 'aarch64' or platform_machine == 'arm64' or (sys_platform == 'win32' and platform_machine == 'ARM64')",
@@ -32,12 +28,21 @@ dev = [
     "pytest>=8.3",
     "ruff>=0.11",
     "ipykernel>=7.2",
+    # test_vertex.py serializes a real sklearn model in upload_model_joblib tests
+    "scikit-learn>=1.5.0,<2",
 ]
 # The inference-server Docker images are not part of the published library;
-# this group exists only for building those images.
+# this group exists only for building those images. pandas, scikit-learn, and
+# xgboost aren't imported by the library — the images need them to unpickle
+# and run joblib model artifacts (and pandas for the sklearn server's
+# DataFrame input). Serving versions must stay compatible with the versions
+# models were trained with.
 server = [
     "kserve>=0.16,<0.17",
     "python-json-logger>=4.0,<5",
+    "pandas>=2.0,<3",
+    "scikit-learn>=1.5.0,<2",
+    "xgboost>=2.0.0,<3",
 ]
 
 # kserve pins psutil<6, but psutil 5.x ships no Linux arm64 wheels, so local

--- a/uv.lock
+++ b/uv.lock
@@ -539,34 +539,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fsspec"
-version = "2026.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
-]
-
-[[package]]
-name = "gcsfs"
-version = "2026.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "decorator" },
-    { name = "fsspec" },
-    { name = "google-auth" },
-    { name = "google-auth-oauthlib" },
-    { name = "google-cloud-storage" },
-    { name = "google-cloud-storage-control" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/33/58e23c6f492e091c2f01ae1bffe331aa97e18a0b3d24ff90ef648335ddc8/gcsfs-2026.7.0.tar.gz", hash = "sha256:2df36ce1e9010e76dc4295774030495a97496838483c619e9f63bc0ab7bdc770", size = 1265874, upload-time = "2026-07-06T15:02:30.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/eb/a5c4b39903928e6be7735cc7aa31b6c3bbf3d887419e1e7ac751dba02233/gcsfs-2026.7.0-py3-none-any.whl", hash = "sha256:8ce6c08ea64302d8fd4bc23a615ccd9e7752541cde1a88ec8362109bd79cde78", size = 91131, upload-time = "2026-07-06T15:02:29.208Z" },
-]
-
-[[package]]
 name = "google-api-core"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -607,19 +579,6 @@ pyopenssl = [
 ]
 requests = [
     { name = "requests" },
-]
-
-[[package]]
-name = "google-auth-oauthlib"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "requests-oauthlib" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
 ]
 
 [[package]]
@@ -709,23 +668,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/ac/60b4cb0a6c8c6bb7cedb8971ba5e34a94096acf76e2cc242bcf1e6fc5c49/google_cloud_storage-3.12.1.tar.gz", hash = "sha256:1d81491c7663bc26c5056d00b834356f2253b910ef467f9cf9928a87fca1e04b", size = 17339353, upload-time = "2026-07-08T17:03:59.142Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/ca176e95bafac0fe7befeee7e0420e686de147571cd2908e308c5fe71bda/google_cloud_storage-3.12.1-py3-none-any.whl", hash = "sha256:9297ae0c2ce3f5400b1f2bb3a3e6d2cd256614366e03cd30600871df8e903afb", size = 340845, upload-time = "2026-07-08T17:03:31.418Z" },
-]
-
-[[package]]
-name = "google-cloud-storage-control"
-version = "1.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "grpc-google-iam-v1" },
-    { name = "grpcio" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/88/ae/707995271f77e3c1da715c740160f98f87a79a5c601b28d17c4d2500c037/google_cloud_storage_control-1.12.0.tar.gz", hash = "sha256:49090d03532c0c84c6246a5fd490c31fd4bbffb4c7771c0a6744ec23a194a5f6", size = 137036, upload-time = "2026-06-03T16:14:00.921Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/ba/f187f30fb2c8bb5dbb0de0fcb0dec2f8fab0b782ab42facc83ea02628f1b/google_cloud_storage_control-1.12.0-py3-none-any.whl", hash = "sha256:20f7f1252fa5635d47e12f746aa69d719e31eb9405cbbd14cdfba317db27d421", size = 102205, upload-time = "2026-06-03T16:12:43.266Z" },
 ]
 
 [[package]]
@@ -1582,7 +1524,6 @@ name = "orient-express"
 version = "3.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "gcsfs" },
     { name = "google-cloud-aiplatform" },
     { name = "google-cloud-storage" },
     { name = "joblib" },
@@ -1594,15 +1535,11 @@ dependencies = [
     { name = "onnxruntime-gpu", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
     { name = "onnxruntime-gpu", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
     { name = "opencv-python-headless" },
-    { name = "pandas" },
     { name = "pillow" },
     { name = "platformdirs" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
-    { name = "xgboost" },
 ]
 
 [package.dev-dependencies]
@@ -1610,15 +1547,20 @@ dev = [
     { name = "ipykernel" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 server = [
     { name = "kserve" },
+    { name = "pandas" },
     { name = "python-json-logger" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "xgboost" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "gcsfs", specifier = ">=2024.10.0" },
     { name = "google-cloud-aiplatform", specifier = ">=1.0,<2" },
     { name = "google-cloud-storage", specifier = ">=3.0,<4" },
     { name = "joblib", specifier = ">=1.3" },
@@ -1626,14 +1568,11 @@ requires-dist = [
     { name = "onnxruntime", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or (platform_machine == 'ARM64' and sys_platform == 'win32') or sys_platform == 'darwin'", specifier = ">=1.20,<2" },
     { name = "onnxruntime-gpu", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')", specifier = ">=1.20,<2" },
     { name = "opencv-python-headless", specifier = ">=4.11.0,<5" },
-    { name = "pandas", specifier = ">=2.0,<3" },
     { name = "pillow", specifier = ">=10.0.1" },
     { name = "platformdirs", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "requests", specifier = ">=2.28" },
-    { name = "scikit-learn", specifier = ">=1.5.0,<2" },
     { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "xgboost", specifier = ">=2.0.0,<3" },
 ]
 
 [package.metadata.requires-dev]
@@ -1641,10 +1580,14 @@ dev = [
     { name = "ipykernel", specifier = ">=7.2" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "ruff", specifier = ">=0.11" },
+    { name = "scikit-learn", specifier = ">=1.5.0,<2" },
 ]
 server = [
     { name = "kserve", specifier = ">=0.16,<0.17" },
+    { name = "pandas", specifier = ">=2.0,<3" },
     { name = "python-json-logger", specifier = ">=4.0,<5" },
+    { name = "scikit-learn", specifier = ">=1.5.0,<2" },
+    { name = "xgboost", specifier = ">=2.0.0,<3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- gcsfs is not being used for anything anymore
- scikit-learn, xgboost, and pandas are only used in tests/ or in the xgboost-scikit-learn serving container, and are hence moved to the server group. Users will need to install their own versions of xgboost and scikit-learn instead of relying on this library's transitive dependencies