### PR TITLE
chore: add pre-commit hooks for ruff format and lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.ruff_cache/
 
 # Translations
 *.mo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+# Runs ruff on `git commit`: ruff-format auto-fixes, ruff-check reports (no fix).
+# ruff only ever touches Python (.py / .pyi / .ipynb), so there's no need to
+# list source dirs — everything else is ignored automatically. We only carve
+# OUT what we don't want linted: analytics/ (separate workspace) and notebooks.
+# ruff-format rewrites files in place; ruff-check only reports (no auto-fix).
+# If formatting changes anything, the commit is aborted so you can review and
+# `git add` the reformatted files, then commit again.
+#
+# One-time setup after cloning:
+#   uv tool install pre-commit    # or: pipx install pre-commit / brew install pre-commit
+#   pre-commit install            # installs the pre-commit hook (see default_install_hook_types)
+#
+# Bypass in an emergency:  git commit --no-verify
+
+default_install_hook_types: [pre-commit]
+
+# Applies to every hook below.
+exclude: '\.ipynb$'
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.21
+    hooks:
+      # Formatting — auto-applied (reformats files in place)
+      - id: ruff-format
+        name: ruff format (auto-fix)
+        stages: [pre-commit]
+
+      # Linting — no auto-fix
+      - id: ruff-check
+        name: ruff lint (check only, no fix)
+        args: [--no-fix]
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary

Adds a `.pre-commit-config.yaml` that runs `ruff-format` and `ruff-check` on `git commit`, so formatting and lint problems surface before a commit lands rather than after a push.

This changes nothing about what is enforced — CI already runs `ruff check .` and `ruff format --check .`, and `[tool.ruff]` in `pyproject.toml` is unchanged. It only changes *when* you find out. The codebase is already clean, so nothing is reformatted by adding this.

## Changes

- **`.pre-commit-config.yaml`** (new) — `ruff-format` auto-fixes in place, `ruff-check` reports with `--no-fix`. Pinned to `v0.15.21`, matching the ruff version the project resolves, so the hooks and CI cannot disagree. Notebooks are excluded (`exclude: '\.ipynb$'`) because `test_docker_image.ipynb` is a working document kept with its outputs — this mirrors `extend-exclude = ["*.ipynb"]` already in `[tool.ruff]`.
- **`.gitignore`** — ignore `.ruff_cache/`, which the hooks create locally.

## Breaking Changes

None.

## Test Plan

- [x] `pre-commit run --all-files` — both hooks pass and **no files are modified**, confirming the hooks agree with the current tree rather than reformatting on first use.
- [x] `uv run ruff check .` → `All checks passed!` and `uv run ruff format --check .` → `50 files already formatted`, unchanged by this PR.
- [x] Hook pin matches the resolved toolchain: `ruff --version` reports `0.15.21`, the same as `rev: v0.15.21`.
- [ ] Confirm CI is green on this branch (no workflow change, so expected — worth eyeballing once).

Not covered here, left for follow-up on the issue:

- [ ] `pre-commit` is still **not** a declared dependency, so `uv run pre-commit install` fails and it has to be installed globally (`uvx pre-commit` / `uv tool install pre-commit`) — which is how it was run for the check above.
- [ ] `README.md` does not yet mention the hooks or the one-time `pre-commit install`.

## Related Issues

- Closes #55

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shiftsmartinc/codesmith/orient-express/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788643656&installation_model_id=423145&pr_number=56&repository=shiftsmartinc%2Forient-express&return_to=https%3A%2F%2Fgithub.com%2Fshiftsmartinc%2Forient-express%2Fpull%2F56&signature=c406252a1e383e373fc2ed65415ca7a5777232ca9af8e18a6a0b09eb7719c846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code formatting and lint checks during commits.
  * Excluded notebook files from commit-time checks.
  * Updated ignored files to exclude Ruff’s local cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->