### PR TITLE
perf(image_processor): resolve JPEG scan status with numpy on the common path

### DIFF
--- a/orient_express/utils/image_processor.py
+++ b/orient_express/utils/image_processor.py
@@ -161,28 +161,12 @@ _SCAN_SEGMENT_MARKERS = frozenset(
 )
 
 
-def _jpeg_scan_status(data: bytes):
-    """Classify a JPEG's entropy stream: 'complete', 'truncated' or 'corrupt'.
+def _jpeg_scan_walk(data: bytes, pos: int):
+    """The exact byte walk, from `pos` inside the entropy stream.
 
-    Returns None when the data is not a walkable JPEG (the decoders judge
-    those).
-
-    A structural byte walk, not a decode, so it costs a tiny fraction of
-    one. Inside a scan, FF may only be followed by 00 (stuffed data byte),
-    D0-D7 (restart), FF (fill), D9 (EOI), or a segment marker — anything
-    else means the entropy data was damaged (e.g. an interrupted upload
-    that spliced garbage into the stream). Walking from the first SOS
-    makes the truncation verdict immune to EXIF thumbnails (their EOI
-    sits before the scan) and to trailing non-JPEG bytes such as motion
-    photos' appended video (they sit after the real EOI). Damage with no
-    FF violations (e.g. zeroed spans) is invisible here — but libjpeg
-    decodes that without complaint too, so no stream-level check catches
-    it.
+    Kept as the reference implementation and the fallback for anything the
+    vectorised pass in _jpeg_scan_status cannot decide.
     """
-    pos = _jpeg_scan_start(data)
-    if pos is None:
-        return None
-    pos = pos + 2 + int.from_bytes(data[pos + 2 : pos + 4], "big")  # skip SOS hdr
     end = len(data)
     while True:
         idx = data.find(b"\xff", pos)
@@ -204,6 +188,68 @@ def _jpeg_scan_status(data: bytes):
             pos = idx + 2 + segment_length
         else:
             return "corrupt"
+
+
+def _jpeg_scan_status(data: bytes):
+    """Classify a JPEG's entropy stream: 'complete', 'truncated' or 'corrupt'.
+
+    Returns None when the data is not a walkable JPEG (the decoders judge
+    those).
+
+    A structural byte walk, not a decode, so it costs a tiny fraction of
+    one. Inside a scan, FF may only be followed by 00 (stuffed data byte),
+    D0-D7 (restart), FF (fill), D9 (EOI), or a segment marker — anything
+    else means the entropy data was damaged (e.g. an interrupted upload
+    that spliced garbage into the stream). Walking from the first SOS
+    makes the truncation verdict immune to EXIF thumbnails (their EOI
+    sits before the scan) and to trailing non-JPEG bytes such as motion
+    photos' appended video (they sit after the real EOI). Damage with no
+    FF violations (e.g. zeroed spans) is invisible here — but libjpeg
+    decodes that without complaint too, so no stream-level check catches
+    it.
+
+    The walk itself is one Python loop iteration per FF byte — roughly two
+    thousand of them in a 500KB photo — and it holds the GIL throughout, so
+    on a decode thread pool it serialises against every other thread
+    (measured: 1.11x across 8 threads, i.e. no scaling at all). The common
+    case never needs the loop: a healthy scan contains only FF00 (stuffed
+    data) and FFD0-D7 (restart markers) before its FFD9, and the walk
+    advances pos=idx+2 through every one of them, visiting exactly the FF
+    positions numpy finds in a single C-level pass. Only a segment marker
+    (whose length field makes the walk *skip* bytes, so later FFs may not be
+    real scan positions) or an FF fill makes position history matter, and
+    those fall back to _jpeg_scan_walk. Verdicts are identical by
+    construction, and test_jpeg_scan_status.py pins that against the walk
+    over mutated and fuzzed inputs.
+
+    The scan still costs real time on a decode pool (it allocates a mask the
+    size of the scan), so it is tempting to skip it for files whose last two
+    bytes are FFD9. Do not: damage mid-stream leaves the tail intact, so 96
+    of 100 deliberately corrupted files still end in EOI, and cv2.imdecode
+    returns pixels for them without complaint — which is precisely what this
+    check exists to catch. A tail check can only answer "is the *header*
+    intact" (e.g. whether an EXIF read can be trusted), never "is the
+    *stream* sound".
+    """
+    pos = _jpeg_scan_start(data)
+    if pos is None:
+        return None
+    pos = pos + 2 + int.from_bytes(data[pos + 2 : pos + 4], "big")  # skip SOS hdr
+    array = np.frombuffer(data, np.uint8)
+    if pos >= len(array) - 1:
+        return _jpeg_scan_walk(data, pos)
+    # every FF that has a following byte; the walk can never look past these
+    marks = np.flatnonzero(array[pos:-1] == 0xFF) + pos
+    if marks.size == 0:
+        return "truncated"  # no FF at all: no EOI either
+    following = array[marks + 1]
+    stuffed = (following == 0x00) | ((following >= 0xD0) & (following <= 0xD7))
+    decisive = np.flatnonzero(~stuffed)
+    if decisive.size == 0:
+        return "truncated"  # only stuffed/restart bytes, stream ran out
+    if following[decisive[0]] == 0xD9:
+        return "complete"
+    return _jpeg_scan_walk(data, pos)
 
 
 def decode_image(

--- a/tests/test_jpeg_scan_status.py
+++ b/tests/test_jpeg_scan_status.py
@@ -1,0 +1,135 @@
+"""Equivalence tests for _jpeg_scan_status's vectorised fast path.
+
+_jpeg_scan_status resolves the common case with numpy and falls back to
+_jpeg_scan_walk — the reference byte walk — for anything position-dependent.
+These tests pin the two to identical verdicts, since the fast path is only
+worth having if it can never disagree.
+"""
+
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from orient_express.utils.image_processor import (
+    _jpeg_scan_start,
+    _jpeg_scan_status,
+    _jpeg_scan_walk,
+)
+
+
+def reference(data: bytes):
+    """The verdict the original implementation produced: walk, no fast path."""
+    pos = _jpeg_scan_start(data)
+    if pos is None:
+        return None
+    return _jpeg_scan_walk(
+        data, pos + 2 + int.from_bytes(data[pos + 2 : pos + 4], "big")
+    )
+
+
+def jpeg_bytes(width=320, height=240, quality=90, progressive=False, seed=0):
+    rng = np.random.default_rng(seed)
+    # noise, not flat colour: a flat image compresses to an entropy stream with
+    # almost no FF bytes, which would not exercise the scan
+    arr = rng.integers(0, 255, (height, width, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(
+        buf, format="JPEG", quality=quality, progressive=progressive
+    )
+    return buf.getvalue()
+
+
+BASELINE = jpeg_bytes()
+PROGRESSIVE = jpeg_bytes(progressive=True)
+
+
+def splice(data: bytes, marker: bytes, at: float = 0.5) -> bytes:
+    out = bytearray(data)
+    i = int(len(out) * at)
+    out[i : i + 2] = marker
+    return bytes(out)
+
+
+CASES = {
+    "baseline": BASELINE,
+    "progressive": PROGRESSIVE,
+    "halved": BASELINE[: len(BASELINE) // 2],
+    "decimated": BASELINE[: len(BASELINE) // 10],
+    "eoi_stripped": BASELINE[:-2],
+    "zero_padded": BASELINE + b"\x00" * 32,
+    "trailing_junk": BASELINE + b"appended video bytes",
+    "spliced_invalid": splice(BASELINE, b"\xff\x3f"),
+    "spliced_segment": splice(BASELINE, b"\xff\xc4"),
+    "spliced_fill": splice(BASELINE, b"\xff\xff"),
+    "spliced_restart": splice(BASELINE, b"\xff\xd0"),
+    "progressive_spliced": splice(PROGRESSIVE, b"\xff\x3f"),
+    "empty": b"",
+    "soi_only": b"\xff\xd8",
+    "not_jpeg": b"this is not a jpeg at all",
+    "sos_header_only": b"\xff\xd8\xff\xda\x00\x02",
+}
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_matches_reference_walk(name):
+    data = CASES[name]
+    assert _jpeg_scan_status(data) == reference(data)
+
+
+def test_random_bytes_match_reference():
+    """Fuzz: arbitrary bytes must never make the two implementations diverge."""
+    rng = np.random.default_rng(1234)
+    for _ in range(300):
+        size = int(rng.integers(0, 4000))
+        data = rng.integers(0, 256, size, dtype=np.uint8).tobytes()
+        assert _jpeg_scan_status(data) == reference(data)
+        # and prefixed with a real SOI/SOS header, so the walk actually starts
+        hybrid = BASELINE[:200] + data
+        assert _jpeg_scan_status(hybrid) == reference(hybrid)
+
+
+def test_verdicts_are_actually_exercised():
+    """Guard the tests above: they prove nothing if every case returns None."""
+    verdicts = {reference(d) for d in CASES.values()}
+    assert {"complete", "truncated", "corrupt"} <= verdicts
+    assert reference(BASELINE) == "complete"
+    assert reference(BASELINE[: len(BASELINE) // 2]) == "truncated"
+    assert reference(splice(BASELINE, b"\xff\x3f")) == "corrupt"
+
+
+def test_corrupt_stream_can_still_end_in_eoi():
+    r"""Why the cheap tail check is not a substitute for the scan.
+
+    Damage mid-stream leaves the tail intact, so `data.endswith(b'\\xff\\xd9')`
+    reports a corrupt file as healthy — and cv2.imdecode returns pixels for it
+    without complaint, which is the whole reason this scan exists. The tail
+    check is only valid for "is the *header* intact" (e.g. trusting an EXIF
+    read), never for "is the *stream* sound".
+    """
+    corrupt = splice(BASELINE, b"\xff\x3f")
+    assert _jpeg_scan_status(corrupt) == "corrupt"
+    assert corrupt.endswith(b"\xff\xd9")
+
+
+def test_fast_path_resolves_healthy_images_without_the_walk(monkeypatch):
+    """The speedup only exists if healthy files never reach the walk."""
+    calls = []
+    original = _jpeg_scan_walk
+
+    def spy(data, pos):
+        calls.append(pos)
+        return original(data, pos)
+
+    monkeypatch.setattr("orient_express.utils.image_processor._jpeg_scan_walk", spy)
+    for seed in range(20):
+        assert _jpeg_scan_status(jpeg_bytes(seed=seed)) == "complete"
+    assert calls == []
+
+    # a segment marker inside the scan IS position-dependent (its length field
+    # makes the walk skip bytes), so it must fall back
+    assert _jpeg_scan_status(splice(BASELINE, b"\xff\xc4")) == reference(
+        splice(BASELINE, b"\xff\xc4")
+    )
+    assert calls


### PR DESCRIPTION
## What

`_jpeg_scan_status` runs on every decoded image. It was one Python loop iteration per `FF` byte — ~2000 of them in a 500KB photo — holding the GIL throughout, so on a decode thread pool it serialises against every other thread: **1.11x across 8 threads, i.e. no scaling at all**.

A healthy entropy stream only ever contains `FF00` (stuffed data) and `FFD0-D7` (restart markers) before its `FFD9`, and the walk advances `pos = idx+2` through every one of them — visiting exactly the FF positions numpy finds in a single C-level pass. So this takes that pass first and falls back to the walk only when position history matters: a segment marker (whose length field makes the walk *skip* bytes, so later FFs may not be real scan positions) or an FF fill.

The walk moves to `_jpeg_scan_walk` and stays load-bearing — it is both the fallback and the reference the fast path is tested against.

## Numbers

299 real production photos:

| | time | thread scaling |
|---|---|---|
| original walk | 77.9 ms | 1.11x across 8 threads |
| vectorised + fallback | **27.5 ms** | 1.27x |

**All 299 resolved on the fast path**; only damaged files reach the walk (191 of 300 mutated variants did).

This came out of profiling an L4 ingest pipeline where the scan cost **0.76s per 1000 images — more than the nvJPEG decode itself (0.43s)**.

## Correctness

Verdicts are unchanged by construction. Verified over 2,895 cases during development (real photos plus halved / decimated / spliced-`FF3F` / spliced-DHT / spliced-`FFFF` / EOI-stripped / zero-padded variants, random byte strings, and empty/non-JPEG inputs) covering all four outcomes — **0 mismatches**.

`tests/test_jpeg_scan_status.py` pins that in CI: baseline and progressive JPEGs, the mutation set, 600 fuzzed inputs, a guard that the sampled verdicts actually include `complete`/`truncated`/`corrupt` (so the equivalence assertions can't pass vacuously), and a spy asserting healthy images never touch the walk.

## One trap, documented in the docstring

The scan is still not cheap — it allocates a mask the size of the scan — so skipping it for files ending in `FFD9` looks attractive. **Don't.** Damage mid-stream leaves the tail intact: 96 of 100 deliberately corrupted files still end in EOI, and `cv2.imdecode` returns pixels for them without complaint, which is the whole reason this check exists. A tail check can only answer *"is the header intact"* (e.g. whether an EXIF read can be trusted), never *"is the stream sound"*. There's a test for it.

## Known tradeoff

The fast path allocates a boolean mask the size of the scan where the walk allocated nothing — ~500KB for a typical photo, ~4MB across 8 decode threads. Negligible at photo sizes; if very large files (e.g. 50MB motion photos) ever go through this, it would want chunking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shiftsmartinc/codesmith/orient-express/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789325118&installation_model_id=423145&pr_number=62&repository=shiftsmartinc%2Forient-express&return_to=https%3A%2F%2Fgithub.com%2Fshiftsmartinc%2Forient-express%2Fpull%2F62&signature=32075aa5a871699a2b61a91783b899cc259720e034a127d564335eb9aff93c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->